### PR TITLE
fixed error to make terminal.rs work on windows

### DIFF
--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -210,7 +210,7 @@ impl TerminalConnection {
                 cmd.env("TERM", "xterm-256color");
                 cmd
             }
-            TerminalKind::GitBash { working_directory: _ } => {
+            TerminalKind::GitBash { working_directory } => {
                 #[cfg(target_os = "windows")]
                 {
                     let git_bash_paths = [
@@ -231,9 +231,7 @@ impl TerminalConnection {
                     cmd.arg("--login");
                     cmd.arg("-i");
 
-                    if let Some(working_dir) =
-                        working_directory.as_ref().or(config.working_dir.as_ref())
-                    {
+                    if let Some(working_dir) = working_directory.as_ref().or(config.working_dir.as_ref()) {
                         cmd.cwd(working_dir);
                     }
 
@@ -246,8 +244,8 @@ impl TerminalConnection {
                 }
             }
             TerminalKind::Wsl {
-                distribution: _,
-                working_directory: _,
+                distribution,
+                working_directory,
             } => {
                 #[cfg(target_os = "windows")]
                 {


### PR DESCRIPTION
made some changes in the GitBash terminal handling to simplify working directory assignment for WSL @kais-radwan 
![image](https://github.com/user-attachments/assets/9a5c2048-40d8-44f0-8aed-d2de0eff07a1)
