### PR TITLE
Revert "fixed error to make terminal.rs work on windows"

### DIFF
--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -210,7 +210,7 @@ impl TerminalConnection {
                 cmd.env("TERM", "xterm-256color");
                 cmd
             }
-            TerminalKind::GitBash { working_directory } => {
+            TerminalKind::GitBash { working_directory: _ } => {
                 #[cfg(target_os = "windows")]
                 {
                     let git_bash_paths = [
@@ -231,7 +231,9 @@ impl TerminalConnection {
                     cmd.arg("--login");
                     cmd.arg("-i");
 
-                    if let Some(working_dir) = working_directory.as_ref().or(config.working_dir.as_ref()) {
+                    if let Some(working_dir) =
+                        working_directory.as_ref().or(config.working_dir.as_ref())
+                    {
                         cmd.cwd(working_dir);
                     }
 
@@ -244,8 +246,8 @@ impl TerminalConnection {
                 }
             }
             TerminalKind::Wsl {
-                distribution,
-                working_directory,
+                distribution: _,
+                working_directory: _,
             } => {
                 #[cfg(target_os = "windows")]
                 {


### PR DESCRIPTION
Reverts #37 
reason for revert
1.  it is throwing warnings on linux and windows both 
images:- 
![image](https://github.com/user-attachments/assets/00e21aa2-1bc8-4d4d-8863-02b5c52d5951)
![image](https://github.com/user-attachments/assets/8ede5532-cefb-4695-9861-5cbf192b9fd6)
2. It changes nothing for me that's why i asked for a video 
the windows image is taken from @kais-radwan review on #37 