### PR TITLE
Fix terminal compiler error on Windows

### DIFF
--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -282,16 +282,14 @@ impl TerminalConnection {
                     return Err(anyhow!("Git Bash is only available on Windows"));
                 }
             }
-            TerminalKind::Wsl { distribution: _, working_directory: _ } => {
+            TerminalKind::Wsl { distribution, working_directory: _ } => {
                 #[cfg(target_os = "windows")]
                 {
                     let mut cmd = CommandBuilder::new("wsl");
 
-                    if let Some(dist) = &config.kind {
-                        if let TerminalKind::Wsl { distribution: Some(dist_name), .. } = dist {
-                            cmd.arg("-d");
-                            cmd.arg(dist_name);
-                        }
+                    if let Some(dist_name) = distribution {
+                        cmd.arg("-d");
+                        cmd.arg(dist_name);
                     }
 
                     if let Some(wd) = config.working_dir.as_ref() {


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a type mismatch compilation error that occurs when building the terminal module on Windows. The error was caused by redundant pattern matching in the WSL terminal configuration logic.

- Fixed type mismatch error in `TerminalKind::Wsl` match arm in `src-tauri/src/terminal.rs`
- Removed redundant pattern matching against `&config.kind` within the WSL match arm
- Ensures the code compiles correctly on Windows while maintaining the same functionality

## Screenshots/Videos
N/A

## Related Issues
N/A