### PR TITLE
Update LSP rust-analyzer configuration and client handling

### DIFF
--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -212,6 +212,7 @@ pub struct StartLSPRequest {
     command: String,
     args: Vec<String>,
     working_dir: String,
+    initialization_options: Option<serde_json::Value>,
 }
 
 #[tauri::command]
@@ -273,7 +274,7 @@ pub async fn start_lsp_server(
 
     let initialize_params = InitializeParams {
         process_id: Some(pid),
-        initialization_options: None,
+        initialization_options: request.initialization_options,
         capabilities: ClientCapabilities {
             workspace: Some(WorkspaceClientCapabilities {
                 apply_edit: Some(true),

--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -27,7 +27,9 @@ import "prismjs/components/prism-markup-templating";
 import "prismjs/components/prism-php";
 import "prismjs/components/prism-python";
 import "prismjs/components/prism-ruby";
+import "prismjs/components/prism-rust";
 import "prismjs/components/prism-sql";
+import "prismjs/components/prism-toml";
 import "prismjs/components/prism-typescript";
 import "prismjs/components/prism-yaml";
 
@@ -100,6 +102,8 @@ const getLanguageFromFilename = (filename: string): string => {
     php4: "php",
     php5: "php",
     php7: "php",
+    rs: "rust",
+    toml: "toml",
   };
 
   return languageMap[ext || ""] || "text";

--- a/src/lsp/configs.ts
+++ b/src/lsp/configs.ts
@@ -1,71 +1,97 @@
-import { LSPConfig } from './types';
+import { LSPConfig } from "./types";
 
 export const LSP_CONFIGS: Record<string, LSPConfig> = {
   ruby: {
-    command: 'solargraph',
-    args: ['stdio'],
-    fileExtensions: ['.rb', '.ruby'],
+    command: "solargraph",
+    args: ["stdio"],
+    fileExtensions: [".rb", ".ruby"],
     initializationOptions: {
       diagnostics: true,
       formatting: true,
-      useBundler: false
-    }
+      useBundler: false,
+    },
   },
 
   typescript: {
-    command: 'typescript-language-server',
-    args: ['--stdio'],
-    fileExtensions: ['.ts', '.tsx'],
+    command: "typescript-language-server",
+    args: ["--stdio"],
+    fileExtensions: [".ts", ".tsx"],
     initializationOptions: {
       preferences: {
         includeCompletionsForModuleExports: true,
-        includeCompletionsWithInsertText: true
-      }
-    }
+        includeCompletionsWithInsertText: true,
+      },
+    },
   },
 
   javascript: {
-    command: 'typescript-language-server',
-    args: ['--stdio'],
-    fileExtensions: ['.js', '.jsx'],
+    command: "typescript-language-server",
+    args: ["--stdio"],
+    fileExtensions: [".js", ".jsx"],
     initializationOptions: {
       preferences: {
         includeCompletionsForModuleExports: true,
-        includeCompletionsWithInsertText: true
-      }
-    }
+        includeCompletionsWithInsertText: true,
+      },
+    },
   },
 
   python: {
-    command: 'pylsp',
+    command: "pylsp",
     args: [],
-    fileExtensions: ['.py'],
+    fileExtensions: [".py"],
     initializationOptions: {
       settings: {
         pylsp: {
           plugins: {
             pycodestyle: { enabled: true },
             pyflakes: { enabled: true },
-            autopep8: { enabled: true }
-          }
-        }
-      }
-    }
-  }
+            autopep8: { enabled: true },
+          },
+        },
+      },
+    },
+  },
+
+  rust: {
+    command: "rust-analyzer",
+    args: [],
+    fileExtensions: [".rs"],
+    initializationOptions: {
+      cargo: {
+        features: "all",
+      },
+      procMacro: {
+        enable: true,
+      },
+      inlayHints: {
+        enable: true,
+        parameterHints: true,
+        typeHints: true,
+      },
+      // completion: {
+      //   addCallArgumentSnippets: true,
+      //   addCallParenthesis: true,
+      //   postfix: {
+      //     enable: true
+      //   }
+      // }
+    },
+  },
 };
 
 export function getLanguageFromPath(filePath: string): string | null {
-  const extension = '.' + filePath.split('.').pop()?.toLowerCase();
-  
+  const extension = "." + filePath.split(".").pop()?.toLowerCase();
+
   for (const [language, config] of Object.entries(LSP_CONFIGS)) {
     if (config.fileExtensions.includes(extension)) {
       return language;
     }
   }
-  
+
   return null;
 }
 
 export function isLanguageSupported(filePath: string): boolean {
   return getLanguageFromPath(filePath) !== null;
-} 
+}

--- a/src/lsp/lsp-client.ts
+++ b/src/lsp/lsp-client.ts
@@ -22,6 +22,7 @@ export class LSPClient {
           command: this.config.command,
           args: this.config.args,
           working_dir: workspaceRoot,
+          initialization_options: this.config.initializationOptions || null,
         },
       });
 


### PR DESCRIPTION
## Summary
- Enhanced rust-analyzer LSP integration in the Tauri backend
- Updated code editor component to better support LSP features
- Improved LSP client configuration and handling

## Changes
- Modified `src-tauri/src/lsp.rs` for better rust-analyzer integration
- Updated `src/components/code-editor.tsx` for improved LSP support
- Enhanced LSP configurations in `src/lsp/configs.ts`
- Improved LSP client implementation in `src/lsp/lsp-client.ts`

## Important Note
There is an `onclick` handler that triggers LSP requests when users click on parts of the buffer, causing rust-analyzer to be triggered frequently. This is a separate issue that should be addressed in a future PR to optimize LSP request handling.

## Test Plan
- [ ] Test rust-analyzer functionality in the editor
- [ ] Verify LSP features work correctly (autocomplete, hover, diagnostics)
- [ ] Ensure no regressions in editor functionality