### PR TITLE
Fix terminal hijacking global keyboard shortcuts

### DIFF
--- a/src/components/terminal/terminal-container.tsx
+++ b/src/components/terminal/terminal-container.tsx
@@ -129,10 +129,12 @@ const TerminalContainer = ({ currentDirectory = "/", className = "" }: TerminalC
   );
 
   // Terminal-specific keyboard shortcuts
+  // Terminal-specific keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Only handle shortcuts when the terminal container is active
-      if (!document.querySelector('[data-terminal-container="active"]')) {
+      // Only handle shortcuts when the terminal container or its children have focus
+      const terminalContainer = document.querySelector('[data-terminal-container="active"]');
+      if (!terminalContainer || !terminalContainer.contains(document.activeElement)) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- Fixed terminal intercepting global keyboard shortcuts when visible but not focused
- Terminal shortcuts now only work when terminal or its children have focus

## Problem
When the terminal pane was visible, it would intercept keyboard shortcuts like `Cmd+W` even when the user was working in the editor. This prevented users from closing tabs and using other global shortcuts.

## Solution
Modified the keyboard event handler in `TerminalContainer` to check if the terminal or any of its child elements have focus before processing shortcuts. This ensures terminal shortcuts only work in the appropriate context.