### PR TITLE
Feat:Added Undo and Redo functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,10 @@ function App() {
   const { settings, updateSetting, updateSettingsFromJSON } = useSettings();
   const quickEdit = useQuickEdit();
 
+  // Get undo/redo methods from store
+  const undo = useCodeEditorStore(state => state.undo);
+  const redo = useCodeEditorStore(state => state.redo);
+
   // Context menus hook
   const contextMenus = useContextMenus({
     folderHeaderContextMenu: uiState.folderHeaderContextMenu,
@@ -568,16 +572,10 @@ function App() {
       }
     },
     onUndo: () => {
-      if (codeEditorRef.current?.textarea) {
-        const store = useCodeEditorStore.getState();
-        store.undo();
-      }
+      undo();
     },
     onRedo: () => {
-      if (codeEditorRef.current?.textarea) {
-        const store = useCodeEditorStore.getState();
-        store.redo();
-      }
+      redo();
     },
     onFind: () => {
       setIsFindVisible(true);

--- a/src/hooks/use-editor-keyboard.ts
+++ b/src/hooks/use-editor-keyboard.ts
@@ -17,8 +17,6 @@ export const useEditorKeyboard = (
   const language = useCodeEditorStore(state => state.language);
   const vimEnabled = useCodeEditorStore(state => state.vimEnabled);
   const value = useCodeEditorStore(state => state.value);
-  const undo = useCodeEditorStore(state => state.undo);
-  const redo = useCodeEditorStore(state => state.redo);
 
   // Store actions
   const nextLspCompletion = useCodeEditorStore(state => state.nextLspCompletion);
@@ -57,21 +55,6 @@ export const useEditorKeyboard = (
       const textarea = e.currentTarget;
       const currentValue = textarea.value;
       const { selectionStart, selectionEnd } = textarea;
-      const cmdKey = isMac() ? e.metaKey : e.ctrlKey;
-
-      // Handle undo/redo
-      if (cmdKey && e.key === "z") {
-        e.preventDefault();
-        if (e.shiftKey) {
-          redo();
-        } else {
-          undo();
-        }
-        return;
-      }
-
-      // History is now handled in handleContentChange to avoid duplicates
-      // Remove the pushToHistory calls from here
 
       // Handle LSP completion navigation
       if (isLspCompletionVisible && lspCompletions.length > 0) {
@@ -105,6 +88,8 @@ export const useEditorKeyboard = (
 
       // Handle regular editor shortcuts
       if (!vimEnabled) {
+        const cmdKey = isMac() ? e.metaKey : e.ctrlKey;
+
         // Tab handling
         if (e.key === "Tab") {
           e.preventDefault();
@@ -259,8 +244,6 @@ export const useEditorKeyboard = (
       language,
       onChange,
       onKeyDown,
-      undo,
-      redo,
     ],
   );
 


### PR DESCRIPTION
# Pull Request

This PR adds the ability to redo/undo in the editor with keyboard Shortcuts.

## Description

- Added Undo and Redo State in the code editor store  

- Updated the Keyboard Handler to use CTRL + Z or CMD + Z (on mac) for undo and CTRL+SHIFT+Z or CMD+SHIFT+Z(on mac)


## Screenshots/Videos


https://github.com/user-attachments/assets/c1512684-c967-430a-9d39-3b059c202872




