### PR TITLE
Remove native window controls on linux

### DIFF
--- a/src/components/window/custom-title-bar.tsx
+++ b/src/components/window/custom-title-bar.tsx
@@ -83,6 +83,7 @@ const CustomTitleBar = ({ showMinimal = false, isWelcomeScreen = false }: Custom
   };
 
   const isMacOS = currentPlatform === "macos";
+  const isLinux = currentPlatform === "linux";
 
   if (showMinimal) {
     const backgroundClass = isWelcomeScreen
@@ -100,8 +101,8 @@ const CustomTitleBar = ({ showMinimal = false, isWelcomeScreen = false }: Custom
       >
         <div className="flex-1" />
 
-        {/* Windows controls */}
-        {!isMacOS && (
+        {/* Window controls - only show on Linux */}
+        {isLinux && (
           <div className="flex items-center">
             <button
               onClick={handleMinimize}


### PR DESCRIPTION
# Pull Request


---

**This PR ensures correct, native-feeling window controls and title bar behavior across all platforms:**

- **Native window decorations are enabled by default** (`"decorations": true` in `tauri.conf.json`), so macOS and Windows always show their native window controls (traffic lights or minimize/maximize/close).
- **Platform-specific decoration logic is handled in Rust** (`main.rs`):
  - On **Linux**, window decorations are disabled at runtime, so only the custom title bar is visible.
  - On **macOS** and **Windows**, decorations remain enabled for native controls.
- **Custom title bar window controls (minimize, maximize, close)** are now **only shown on Linux**. On macOS and Windows, these controls are hidden, so there are no duplicate controls.
- **Settings and AI Chat buttons** in the custom title bar remain visible and functional on all platforms.

**Result:**
- **macOS:** Only native traffic lights are shown (no duplicate controls).
- **Windows:** Only native window controls are shown.
- **Linux:** Only the custom title bar controls are shown.

---



## Screenshots/Videos

<img width="1890" height="1017" alt="image" src="https://github.com/user-attachments/assets/f4b62364-502a-463d-a07b-1d1f2b5561d3" />

Closes #145 Fixes #145


