### PR TITLE
Forbidden paths now able to read

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -21,10 +21,8 @@
     "fs:default",
     {
       "identifier": "fs:scope",
-      "allow": [
-        { "path": "$HOME" },
-        { "path": "$HOME/**" }
-      ]
+      "allow": [{ "path": "$HOME/**" }],
+      "requireLiteralLeadingDot": false
     },
     "fs:allow-read-file",
     "fs:allow-write-file",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,5 +52,10 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "fs": {
+      "requireLiteralLeadingDot": false
+    }
   }
 }


### PR DESCRIPTION
# Pull Request

Was not able to read .env, .gitignore files. Now they are able to read.

## Screenshots/Videos

**Before**
<img width="1501" height="1037" alt="image" src="https://github.com/user-attachments/assets/9f75ef60-b6b1-4f16-911d-876460f0b904" />

**After**
<img width="1501" height="1037" alt="image" src="https://github.com/user-attachments/assets/79ecc30e-d0b6-4647-a7c6-56e5688bd47f" />

