### PR TITLE
Format `theme.rs` to prevent Rust CI failure

### DIFF
--- a/src-tauri/src/commands/theme.rs
+++ b/src-tauri/src/commands/theme.rs
@@ -1,28 +1,25 @@
-use std::process::Command;
-use std::fs;
-use std::path::Path;
-use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs, path::Path, process::Command};
 use tauri::State;
 use tokio::sync::RwLock;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TomlTheme {
-    pub id: String,
-    pub name: String,
-    pub description: String,
-    pub category: String, // "System" | "Light" | "Dark"
-    #[serde(rename = "is_dark")]
-    pub is_dark: Option<bool>,
-    #[serde(rename = "css_variables")]
-    pub css_variables: HashMap<String, String>,
-    #[serde(rename = "syntax_tokens")]
-    pub syntax_tokens: Option<HashMap<String, String>>,
+   pub id: String,
+   pub name: String,
+   pub description: String,
+   pub category: String, // "System" | "Light" | "Dark"
+   #[serde(rename = "is_dark")]
+   pub is_dark: Option<bool>,
+   #[serde(rename = "css_variables")]
+   pub css_variables: HashMap<String, String>,
+   #[serde(rename = "syntax_tokens")]
+   pub syntax_tokens: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TomlThemeFile {
-    pub themes: Vec<TomlTheme>,
+   pub themes: Vec<TomlTheme>,
 }
 
 pub type ThemeCache = RwLock<HashMap<String, TomlTheme>>;
@@ -133,100 +130,115 @@ pub async fn get_system_theme() -> Result<String, String> {
 }
 
 pub fn load_theme_from_toml(toml_path: &Path) -> Result<Vec<TomlTheme>, String> {
-    let content = fs::read_to_string(toml_path)
-        .map_err(|e| format!("Failed to read theme file {}: {}", toml_path.display(), e))?;
-    
-    let theme_file: TomlThemeFile = toml::from_str(&content)
-        .map_err(|e| format!("Failed to parse TOML theme file {}: {}", toml_path.display(), e))?;
-    
-    Ok(theme_file.themes)
+   let content = fs::read_to_string(toml_path)
+      .map_err(|e| format!("Failed to read theme file {}: {}", toml_path.display(), e))?;
+
+   let theme_file: TomlThemeFile = toml::from_str(&content).map_err(|e| {
+      format!(
+         "Failed to parse TOML theme file {}: {}",
+         toml_path.display(),
+         e
+      )
+   })?;
+
+   Ok(theme_file.themes)
 }
 
 pub fn load_themes_from_directory(themes_dir: &Path) -> Result<Vec<TomlTheme>, String> {
-    let mut all_themes = Vec::new();
-    
-    if !themes_dir.exists() {
-        return Ok(all_themes);
-    }
-    
-    let entries = fs::read_dir(themes_dir)
-        .map_err(|e| format!("Failed to read themes directory {}: {}", themes_dir.display(), e))?;
-    
-    for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
-        let path = entry.path();
-        
-        if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("toml") {
-            match load_theme_from_toml(&path) {
-                Ok(mut themes) => all_themes.append(&mut themes),
-                Err(e) => {
-                    eprintln!("Warning: Failed to load theme from {}: {}", path.display(), e);
-                }
+   let mut all_themes = Vec::new();
+
+   if !themes_dir.exists() {
+      return Ok(all_themes);
+   }
+
+   let entries = fs::read_dir(themes_dir).map_err(|e| {
+      format!(
+         "Failed to read themes directory {}: {}",
+         themes_dir.display(),
+         e
+      )
+   })?;
+
+   for entry in entries {
+      let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+      let path = entry.path();
+
+      if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("toml") {
+         match load_theme_from_toml(&path) {
+            Ok(mut themes) => all_themes.append(&mut themes),
+            Err(e) => {
+               eprintln!(
+                  "Warning: Failed to load theme from {}: {}",
+                  path.display(),
+                  e
+               );
             }
-        }
-    }
-    
-    Ok(all_themes)
+         }
+      }
+   }
+
+   Ok(all_themes)
 }
 
 #[tauri::command]
 pub async fn load_toml_themes(themes_dir: String) -> Result<Vec<TomlTheme>, String> {
-    let themes_path = Path::new(&themes_dir);
-    load_themes_from_directory(themes_path)
+   let themes_path = Path::new(&themes_dir);
+   load_themes_from_directory(themes_path)
 }
 
 #[tauri::command]
 pub async fn load_single_toml_theme(theme_path: String) -> Result<Vec<TomlTheme>, String> {
-    let path = Path::new(&theme_path);
-    load_theme_from_toml(path)
+   let path = Path::new(&theme_path);
+   load_theme_from_toml(path)
 }
 
 #[tauri::command]
 pub async fn get_cached_themes(cache: State<'_, ThemeCache>) -> Result<Vec<TomlTheme>, String> {
-    let themes = cache.read().await;
-    Ok(themes.values().cloned().collect())
+   let themes = cache.read().await;
+   Ok(themes.values().cloned().collect())
 }
 
 #[tauri::command]
 pub async fn cache_themes(
-    themes: Vec<TomlTheme>,
-    cache: State<'_, ThemeCache>,
+   themes: Vec<TomlTheme>,
+   cache: State<'_, ThemeCache>,
 ) -> Result<(), String> {
-    let mut theme_cache = cache.write().await;
-    for theme in themes {
-        theme_cache.insert(theme.id.clone(), theme);
-    }
-    Ok(())
+   let mut theme_cache = cache.write().await;
+   for theme in themes {
+      theme_cache.insert(theme.id.clone(), theme);
+   }
+   Ok(())
 }
 
 #[tauri::command]
 pub async fn get_temp_dir() -> Result<String, String> {
-    let temp_dir = std::env::temp_dir();
-    temp_dir.to_str()
-        .map(|s| s.to_string())
-        .ok_or_else(|| "Failed to convert temp directory path to string".to_string())
+   let temp_dir = std::env::temp_dir();
+   temp_dir
+      .to_str()
+      .map(|s| s.to_string())
+      .ok_or_else(|| "Failed to convert temp directory path to string".to_string())
 }
 
 #[tauri::command]
 pub async fn write_temp_file(file_name: String, content: String) -> Result<(), String> {
-    let temp_dir = std::env::temp_dir();
-    let file_path = temp_dir.join(&file_name);
-    
-    fs::write(&file_path, content)
-        .map_err(|e| format!("Failed to write temp file {}: {}", file_name, e))?;
-    
-    Ok(())
+   let temp_dir = std::env::temp_dir();
+   let file_path = temp_dir.join(&file_name);
+
+   fs::write(&file_path, content)
+      .map_err(|e| format!("Failed to write temp file {}: {}", file_name, e))?;
+
+   Ok(())
 }
 
 #[tauri::command]
 pub async fn delete_temp_file(file_name: String) -> Result<(), String> {
-    let temp_dir = std::env::temp_dir();
-    let file_path = temp_dir.join(&file_name);
-    
-    if file_path.exists() {
-        fs::remove_file(&file_path)
-            .map_err(|e| format!("Failed to delete temp file {}: {}", file_name, e))?;
-    }
-    
-    Ok(())
+   let temp_dir = std::env::temp_dir();
+   let file_path = temp_dir.join(&file_name);
+
+   if file_path.exists() {
+      fs::remove_file(&file_path)
+         .map_err(|e| format!("Failed to delete temp file {}: {}", file_name, e))?;
+   }
+
+   Ok(())
 }


### PR DESCRIPTION
The current Rust formatter set up in [GitHub Actions](https://github.com/athasdev/athas/actions) is generating far too many unnecessary errors.

As a result, many pull requests are flagged with formatting errors in one of the project’s Rust files.

I have reformatted the problematic file, and now `cargo fmt --check --all` in `.github/workflows/rust.yml` should pass cleanly, both for this and for future pull requests. I recommend merging this PR as soon as possible.