### PR TITLE
Prevent native context menu in app 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,17 @@ function App() {
     };
   }, []);
 
+  // Prevent native context menu
+  useEffect(() => {
+    const handleContextMenu = (event: MouseEvent) => {
+      event.preventDefault();
+    };
+    document.addEventListener("contextmenu", handleContextMenu);
+    return () => {
+      document.removeEventListener("contextmenu", handleContextMenu);
+    };
+  }, []);
+
   // Check for remote connection from URL
   const urlParams = new URLSearchParams(window.location.search);
   const remoteParam = urlParams.get("remote");


### PR DESCRIPTION

This PR disables the native OS context menu to prevent accidental application reloads and state loss, which provides a more stable and seamless user experience.

## Description

This change addresses an issue where right-clicking anywhere in the application would trigger the native context menu. This menu's "Refresh" option caused the entire UI to reload, wiping out the user's current session (e.g., any open folder).

The implementation includes the following changes:

-   Added a `useEffect` hook to the root `App.tsx` component to manage a global side-effect.
-   The hook registers an event listener for the `contextmenu` event on the `document` object.
-   The event handler calls `event.preventDefault()`, which effectively stops the native context menu from appearing.
-   A cleanup function is returned from the hook to remove the event listener when the component unmounts, preventing memory leaks.

## Screenshots/Videos

**Before:** Right-clicking anywhere shows the native Windows context menu, including the "Refresh" option.

<img width="1091" height="805" alt="image" src="https://github.com/user-attachments/assets/4453fd8a-d722-4ff3-ba90-c64a35442c88" />


**After:** Right-clicking now has no effect. The native menu is successfully blocked.
<img width="633" height="668" alt="image" src="https://github.com/user-attachments/assets/361968c8-bb0c-4f4b-821d-5f8e2ae21308" />


## Related Issues

Closes #217