### PR TITLE
Increase modal z-index

### DIFF
--- a/src/components/git/git-branch-manager.tsx
+++ b/src/components/git/git-branch-manager.tsx
@@ -184,7 +184,7 @@ const GitBranchManager = ({
 
       {showModal && (
         <div
-          className={cn("fixed inset-0 z-50 flex items-center justify-center", "bg-opacity-50")}
+          className={cn("fixed inset-0 z-100 flex items-center justify-center", "bg-opacity-50")}
           onClick={() => setShowModal(false)}
         >
           <div


### PR DESCRIPTION
Increase the `z-index` to prevent the modal `GitBranchManager` from being covered by the `FileTree` scrollbar or the resize handle from `ResizableSidebar`.

### Screenshots

<img width="1013" height="640" alt="image" src="https://github.com/user-attachments/assets/16585ce0-be43-4560-9de3-903e5446a787" />

Fixes #206


