### PR TITLE
Fix incorrect `z-index` for AI modals and missing cleanup of previous modals

### DIFF
--- a/src/components/api-key-modal.tsx
+++ b/src/components/api-key-modal.tsx
@@ -148,7 +148,7 @@ const ApiKeyModal = ({
   const instructions = getInstructions();
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-150 flex items-center justify-center bg-black/50">
       <div className="flex max-h-[90vh] w-[480px] flex-col rounded-lg border border-border bg-primary-bg">
         {/* Header */}
         <div className="flex items-center justify-between border-border border-b p-4">

--- a/src/components/model-provider-selector.tsx
+++ b/src/components/model-provider-selector.tsx
@@ -42,6 +42,7 @@ const ModelProviderSelector = ({
   const handleApiKeyClick = (e: React.MouseEvent, providerId: string) => {
     e.stopPropagation();
     onApiKeyRequest(providerId);
+    isOpen && setIsOpen(false);
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {


### PR DESCRIPTION
The `z-index` for the `ApiKeyModal` was too low, causing it to be overlapped by the terminal window. Additionally, in the `ModelProviderSelector` modal, when navigating to the API key configuration for a given provider, the previous modal wasn’t closed, which resulted in the `ApiKeyModal` not appearing on top.

### Screenshots

**Before:**

![BeforeAIModals](https://github.com/user-attachments/assets/c2d3bc5c-fc9b-4965-9447-f28144df6103)

**After:**

![AfterAIModals](https://github.com/user-attachments/assets/2e37fb8b-dc60-46f0-8d03-5d3981f7271d)


