### PR TITLE
Add global file system access to capabilities

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -21,7 +21,10 @@
     "fs:default",
     {
       "identifier": "fs:scope",
-      "allow": [{ "path": "$HOME/**" }],
+      "allow": [
+        { "path": "$HOME/**" },
+        { "path": "/**" }
+      ],
       "requireLiteralLeadingDot": false
     },
     "fs:allow-read-file",


### PR DESCRIPTION
Tauri now has access to the entire file system, so there should no longer be any issues with permissions or restricted paths.

### Screenshots

<img width="1312" height="912" alt="image" src="https://github.com/user-attachments/assets/6d7bf3c1-e12d-42af-89bd-5017989dd8f9" />

### Related Issues

Fixes #205 