### PR TITLE
Improve xterm scrollbar styling and container height

### DIFF
--- a/src/components/terminal/terminal.css
+++ b/src/components/terminal/terminal.css
@@ -3,7 +3,6 @@
   position: relative;
   overflow: hidden;
   padding-left: 16px; /* Only add left padding */
-  padding-right: 8px;
 }
 
 /* Ensure xterm doesn't overflow its container */
@@ -31,9 +30,7 @@
 }
 
 .xterm-container .xterm-viewport::-webkit-scrollbar-track {
-  background-color: var(--color-hover);
-  border-radius: 6px;
-  margin: 4px;
+  border-left: 1px solid var(--color-border);
 }
 
 .xterm-container .xterm-viewport::-webkit-scrollbar-thumb {

--- a/src/components/terminal/terminal.tsx
+++ b/src/components/terminal/terminal.tsx
@@ -699,7 +699,7 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
         id={`terminal-${sessionId}`}
         className={cn("xterm-container", "w-full", "text-text", !isActive && "opacity-60")}
         style={{
-          height: "calc(100% - 40px)", // Subtract footer height to prevent content going below
+          height: "calc(100% - 1px)", // Subtract footer height to prevent content going below
         }}
       />
     </div>


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

- Simplified scrollbar track styling by replacing background color and border radius with a subtle left border
- Prevents unnecessary vertical space and ensures terminal content utilizes available space efficiently

> BTW, there is still a 1px gap. I’m working on fixing it and might submit another PR.


## Screenshots/Videos

<table>

<tr>

<td>
Before

<td>
After

<tr>

<td>

<img  alt="image" src="https://github.com/user-attachments/assets/39a1affe-df12-4af7-a53e-5b2d615ae0ef" />

<td>

<img   alt="CleanShot 2025-08-03 at 17 56 55" src="https://github.com/user-attachments/assets/77bc491f-3f7a-423e-9f27-419c28f509cc" />



</table>


https://github.com/user-attachments/assets/daa5e384-6439-4bc8-8693-7736346f2bd4



## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes # Fixes #


