### PR TITLE
Add app version fetching and display in `WelcomeScreen`

### DIFF
--- a/src/components/extensions-view.tsx
+++ b/src/components/extensions-view.tsx
@@ -166,7 +166,7 @@ export default function ExtensionsView({
         </div>
       </div>
 
-      <div className="flex gap-2 p-4 ">
+      <div className="flex gap-2 p-4">
         <Button
           onClick={() => setExtensionsActiveTab("all")}
           variant="ghost"

--- a/src/components/window/welcome-screen.tsx
+++ b/src/components/window/welcome-screen.tsx
@@ -2,7 +2,7 @@ import { AlertCircle, Download, Folder } from "lucide-react";
 import { useEffect, useState } from "react";
 import Button from "@/components/ui/button";
 import { useUpdater } from "@/settings/hooks/use-updater";
-import { fetchAppVersion } from "@/utils/app-utils";
+import { fetchRawAppVersion } from "@/utils/app-utils";
 import { cn } from "@/utils/cn";
 
 interface RecentFolder {
@@ -36,7 +36,7 @@ const WelcomeScreen = ({
 
   useEffect(() => {
     const loadVersion = async () => {
-      const version = await fetchAppVersion();
+      const version = await fetchRawAppVersion();
       setAppVersion(version);
     };
 
@@ -65,7 +65,7 @@ const WelcomeScreen = ({
           <img src="/logo.svg" alt="athas industries" className={cn("h-12")} draggable="false" />
         </div>
         <div className={cn("flex items-center gap-2")}>
-          <p className={cn("paper-text-light font-mono font-normal text-xs")}>{appVersion}</p>
+          <p className={cn("paper-text-light font-mono font-normal text-xs")}>v{appVersion}</p>
           {checking && (
             <div className={cn("paper-text-light text-xs")} title="Checking for updates...">
               ⟳

--- a/src/components/window/welcome-screen.tsx
+++ b/src/components/window/welcome-screen.tsx
@@ -1,6 +1,8 @@
 import { AlertCircle, Download, Folder } from "lucide-react";
+import { useEffect, useState } from "react";
 import Button from "@/components/ui/button";
 import { useUpdater } from "@/settings/hooks/use-updater";
+import { fetchAppVersion } from "@/utils/app-utils";
 import { cn } from "@/utils/cn";
 
 interface RecentFolder {
@@ -20,6 +22,7 @@ const WelcomeScreen = ({
   recentFolders = [],
   onOpenRecentFolder,
 }: WelcomeScreenProps) => {
+  const [appVersion, setAppVersion] = useState<string>("...");
   const {
     available,
     checking,
@@ -30,6 +33,15 @@ const WelcomeScreen = ({
     downloadAndInstall,
     dismissUpdate,
   } = useUpdater(true);
+
+  useEffect(() => {
+    const loadVersion = async () => {
+      const version = await fetchAppVersion();
+      setAppVersion(version);
+    };
+
+    loadVersion();
+  }, []);
 
   const handleRecentFolderClick = (path: string) => {
     if (onOpenRecentFolder) {
@@ -53,7 +65,7 @@ const WelcomeScreen = ({
           <img src="/logo.svg" alt="athas industries" className={cn("h-12")} draggable="false" />
         </div>
         <div className={cn("flex items-center gap-2")}>
-          <p className={cn("paper-text-light font-mono font-normal text-xs")}>v0.1.0</p>
+          <p className={cn("paper-text-light font-mono font-normal text-xs")}>{appVersion}</p>
           {checking && (
             <div className={cn("paper-text-light text-xs")} title="Checking for updates...">
               ⟳

--- a/src/utils/app-utils.ts
+++ b/src/utils/app-utils.ts
@@ -1,21 +1,6 @@
 import { getVersion } from "@tauri-apps/api/app";
 
 /**
- * Fetches the application version from Tauri API
- * @returns Promise<string> - Application version with 'v' prefix (e.g., "v1.0.0")
- */
-export const fetchAppVersion = async (): Promise<string> => {
-  try {
-    const version = await getVersion();
-    return `v${version}`;
-  } catch (error) {
-    console.error("Failed to fetch app version:", error);
-    // Return default version if fetching fails
-    return "v0.1.0";
-  }
-};
-
-/**
  * Fetches the raw application version from Tauri API without 'v' prefix
  * @returns Promise<string> - Raw application version (e.g., "1.0.0")
  */

--- a/src/utils/app-utils.ts
+++ b/src/utils/app-utils.ts
@@ -1,0 +1,31 @@
+import { getVersion } from "@tauri-apps/api/app";
+
+/**
+ * Fetches the application version from Tauri API
+ * @returns Promise<string> - Application version with 'v' prefix (e.g., "v1.0.0")
+ */
+export const fetchAppVersion = async (): Promise<string> => {
+  try {
+    const version = await getVersion();
+    return `v${version}`;
+  } catch (error) {
+    console.error("Failed to fetch app version:", error);
+    // Return default version if fetching fails
+    return "v0.1.0";
+  }
+};
+
+/**
+ * Fetches the raw application version from Tauri API without 'v' prefix
+ * @returns Promise<string> - Raw application version (e.g., "1.0.0")
+ */
+export const fetchRawAppVersion = async (): Promise<string> => {
+  try {
+    const version = await getVersion();
+    return version;
+  } catch (error) {
+    console.error("Failed to fetch app version:", error);
+    // Return default version if fetching fails
+    return "0.1.0";
+  }
+};


### PR DESCRIPTION
To support project scalability, dynamically load the app version (e.g. in `welcome-screen.tsx`) instead of hardcoding it. Use `getVersion()` from the Tauri API (`@tauri-apps/api/app`) with a fallback to `0.1.0` if it fails. For consistency, put the version-fetching logic in a separate file (`src/utils/app-utils.ts`). Since `getVersion()` is async, use a placeholder (`...`) while loading, it’s unlikely users will notice.

### Related Issues

Closes #234
