### PR TITLE
Respect tab size and round line height up in code editor

### DIFF
--- a/src/components/editor/core/text-editor.tsx
+++ b/src/components/editor/core/text-editor.tsx
@@ -25,7 +25,7 @@ import EditorContextMenu from "../overlays/editor-context-menu";
 import { LineBasedEditor } from "./line-based-editor";
 
 export function TextEditor() {
-  const _tabSize = useEditorSettingsStore.use.tabSize();
+  const tabSize = useEditorSettingsStore.use.tabSize();
   const lines = useEditorViewStore.use.lines();
   const { getContent } = useEditorViewStore.use.actions();
   const { updateBufferContent } = useBufferStore.use.actions();
@@ -812,7 +812,7 @@ export function TextEditor() {
           paddingBottom: `${20 * lineHeight}px`, // Add 20 lines worth of bottom padding
           margin: 0,
           whiteSpace: "pre",
-          tabSize: 2,
+          tabSize: tabSize,
           zIndex: 1,
         }}
         autoComplete="off"

--- a/src/components/editor/rendering/editor-viewport.tsx
+++ b/src/components/editor/rendering/editor-viewport.tsx
@@ -26,6 +26,7 @@ export const EditorViewport = memo(
       const showLineNumbers = useEditorSettingsStore.use.lineNumbers();
       const scrollTop = useEditorLayoutStore.use.scrollTop();
       const viewportHeight = useEditorLayoutStore.use.viewportHeight();
+      const tabSize = useEditorSettingsStore.use.tabSize();
       const { lineHeight, gutterWidth } = useEditorLayout();
 
       const selectedLines = useMemo(() => {
@@ -139,6 +140,7 @@ export const EditorViewport = memo(
               height: `${totalHeight}px`,
               minWidth: "100%",
               zIndex: 1,
+              tabSize: tabSize,
             }}
             onClick={onClick}
             onMouseDown={onMouseDown}

--- a/src/utils/editor-position.ts
+++ b/src/utils/editor-position.ts
@@ -58,7 +58,8 @@ export const calculateOffsetFromPosition = (
  * Get line height based on font size
  */
 export const getLineHeight = (fontSize: number): number => {
-  return fontSize * EDITOR_CONSTANTS.LINE_HEIGHT_MULTIPLIER;
+  // Fractional line-height causes subpixel misalignment between textarea and rendered lines
+  return Math.ceil(fontSize * EDITOR_CONSTANTS.LINE_HEIGHT_MULTIPLIER);
 };
 
 /**


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- Respect tab size from user's settings in the textarea
- Round line-height up to prevent subpixel misalignment between textarea and rendered lines

## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #10 


