### PR TITLE
Increase z-index attribute make sure context-menu appears on others

### DIFF
--- a/src/components/editor/overlays/editor-context-menu.tsx
+++ b/src/components/editor/overlays/editor-context-menu.tsx
@@ -235,7 +235,7 @@ const EditorContextMenu = ({
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 w-[200px] select-none rounded-md border border-border bg-secondary-bg py-0.5 shadow-lg"
+      className="fixed z-99 w-[200px] select-none rounded-md border border-border bg-secondary-bg py-0.5 shadow-lg"
       style={{
         left: `${position.x}px`,
         top: `${position.y}px`,


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

editor-context-menu's `z-index` is lower than terminal.

## Screenshots/Videos

| Before | After |
| ---- | --- |
|  <img width="2090" height="1046" alt="CleanShot 2025-08-04 at 11 10 53" src="https://github.com/user-attachments/assets/c5356280-c257-4449-b4df-2cd631531c1d" /> | <img width="1894" height="1130" alt="CleanShot 2025-08-04 at 11 11 23" src="https://github.com/user-attachments/assets/6c331db4-a21e-4c40-bdb9-70c89e141145" /> |


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes # Fixes #


