### PR TITLE
Fix scrolling behavior in diff viewer, file tree, and terminal tab bar

### DIFF
--- a/src/components/diff-viewer/multi-file-diff-viewer.tsx
+++ b/src/components/diff-viewer/multi-file-diff-viewer.tsx
@@ -219,7 +219,22 @@ export const MultiFileDiffViewer = memo(function MultiFileDiffViewer({
       </div>
 
       {/* File List */}
-      <div className="custom-scrollbar flex-1 overflow-y-auto">
+      <div
+        className="custom-scrollbar flex-1 overflow-y-auto"
+        style={{ scrollBehavior: "auto" }} // Override smooth scrolling for manual control
+        onWheel={(e) => {
+          // Minimal handler to ensure scrolling works even when mouse is over DiffLine elements
+          // This prevents child elements from blocking scroll events
+          const container = e.currentTarget;
+
+          // Only handle vertical scrolling to not interfere with horizontal scrolling in code lines
+          if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+            // Use native deltaY to preserve natural mouse acceleration
+            container.scrollTop += e.deltaY;
+            e.preventDefault();
+          }
+        }}
+      >
         {multiDiff.files.map((diff, index) => {
           const summary = fileSummaries[index];
 

--- a/src/components/terminal/terminal-tab-bar.tsx
+++ b/src/components/terminal/terminal-tab-bar.tsx
@@ -383,7 +383,24 @@ const TerminalTabBar = ({
         }}
       >
         {/* Left side - Terminal tabs */}
-        <div className="scrollbar-hidden flex overflow-x-auto" data-tab-container>
+        <div
+          className="scrollbar-hidden flex overflow-x-auto"
+          data-tab-container
+          onWheel={(e) => {
+            // Handle horizontal wheel scrolling with native delta values for natural acceleration
+            const container = e.currentTarget;
+            if (!container) return;
+
+            // Use deltaY for horizontal scrolling (common pattern for horizontal scrollable areas)
+            // Also support deltaX for devices that support horizontal scrolling directly
+            const deltaX = e.deltaX !== 0 ? e.deltaX : e.deltaY;
+
+            container.scrollLeft += deltaX;
+
+            // Prevent default to avoid any browser interference
+            e.preventDefault();
+          }}
+        >
           {sortedTerminals.map((terminal, index) => {
             const isActive = terminal.id === activeTerminalId;
             // Drop indicator should be shown before the tab at dropTarget

--- a/src/file-explorer/views/file-tree.tsx
+++ b/src/file-explorer/views/file-tree.tsx
@@ -696,6 +696,17 @@ const FileTree = ({
         scrollBehavior: "auto", // Disable smooth scrolling
         overscrollBehavior: "contain",
       }}
+      onWheel={(e) => {
+        // Handle wheel scrolling with native delta values for natural acceleration
+        const container = containerRef.current;
+        if (!container) return;
+
+        // Use the native deltaY value to preserve mouse acceleration
+        container.scrollTop += e.deltaY;
+
+        // Prevent default to avoid any browser interference
+        e.preventDefault();
+      }}
       onDragOver={(e) => {
         e.preventDefault();
         if (draggedItem) {


### PR DESCRIPTION
Mouse wheel scrolling was completely broken or super clunky in several key components:

- File tree: Scrollbar was hidden but mouse wheel didn't work at all
- Terminal tab bar: Horizontal scrolling with mouse wheel was impossible when you had many tabs
- Diff viewer: Scrolling was slow and janky, especially when hovering over code lines

I'm added `onWheel` handler to the main container of `FileTree`, horizontal scroll support with mouse wheel for `TerminalTabBar` and fixed the sluggish scrolling that made the app feel broken in `MultiFileDiffViewer`.

`onWheel` handler scrolls naturally everywhere, feels responsive. Uses native acceleration so it feels smooth and natural.

### Screenshots/Videos

#### MultiFileDiffViewer

![MultiFileDiffViewerScroll](https://github.com/user-attachments/assets/33ad420f-db4a-43c7-a710-f6b191c6cada)

#### FileTree

![FileTreeScrollFix](https://github.com/user-attachments/assets/1f6c2cea-fb8b-4d9a-9b95-73b99d953198)

#### TerminalTabBar

![TerminalTabsFix](https://github.com/user-attachments/assets/61b36ba7-6cfe-4f52-b77a-a11f078b12f1)

### Related Issues

Fixes #237 #228 #194
