### PR TITLE
Added git gutter indicators

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -197,6 +197,7 @@ fn main() {
          git_reset_all,
          git_log,
          git_diff_file,
+         git_diff_file_with_content,
          git_commit_diff,
          git_branches,
          git_checkout,

--- a/src/components/editor/editor-stylesheet.tsx
+++ b/src/components/editor/editor-stylesheet.tsx
@@ -177,7 +177,6 @@ export function EditorStylesheet() {
         .gutter-decoration.git-gutter-added,
         .gutter-decoration.git-gutter-modified,
         .gutter-decoration.git-gutter-deleted {
-          border-radius: 2px;
           pointer-events: none;
           transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
           opacity: 0.8;
@@ -282,10 +281,16 @@ export function EditorStylesheet() {
           }
         }
 
+        /* Git gutter spacing and animation */
         .gutter-decoration.git-gutter-added,
         .gutter-decoration.git-gutter-modified,
         .gutter-decoration.git-gutter-deleted {
           animation: gitGutterFadeIn 0.3s ease-out;
+        }
+
+        /* Ensure proper spacing between git indicators and content */
+        .editor-gutter {
+          box-sizing: border-box;
         }
 
         /* Tooltip styling for git gutter */

--- a/src/components/editor/rendering/line-gutter.tsx
+++ b/src/components/editor/rendering/line-gutter.tsx
@@ -41,19 +41,21 @@ export const LineGutter = ({
         height: "100%",
         display: "flex",
         alignItems: "center",
-        justifyContent: showLineNumbers ? "flex-end" : "center",
+        justifyContent: showLineNumbers ? "space-between" : "center",
         position: "relative",
+        paddingLeft: "8px", // Space for git indicators
+        paddingRight: "8px", // Space after line numbers
       }}
       data-line-number={lineNumber}
     >
-      {/* Git gutter indicators positioned absolutely on the left edge */}
+      {/* Git gutter indicators positioned with proper spacing from left edge */}
       {gitDecorations.map((decoration, index) => (
         <div
           key={`git-decoration-${index}`}
           className={cn("gutter-decoration", decoration.className)}
           style={{
             position: "absolute",
-            left: "0px",
+            left: "2px", // Small gap from left edge
             top: decoration.className?.includes("git-gutter-deleted") ? "0px" : "50%",
             transform: decoration.className?.includes("git-gutter-deleted")
               ? "none"
@@ -77,7 +79,7 @@ export const LineGutter = ({
             <span
               style={{
                 position: "absolute",
-                left: "6px",
+                left: "8px", // Increased gap for deleted line indicators
                 top: "-1px",
                 fontSize: "9px",
                 color: "#dc3545",
@@ -89,7 +91,9 @@ export const LineGutter = ({
                 borderRadius: "2px",
                 border: "1px solid rgba(220, 53, 69, 0.3)",
               }}
-            />
+            >
+              {decoration.content}
+            </span>
           )}
         </div>
       ))}
@@ -106,8 +110,8 @@ export const LineGutter = ({
             fontFamily: "inherit",
             userSelect: "none",
             textAlign: "right",
-            minWidth: `${gutterWidth - 8}px`,
-            paddingRight: "4px",
+            minWidth: `${gutterWidth - 24}px`, // Account for git indicator space and padding
+            paddingLeft: "12px", // Space from git indicators
           }}
         >
           {lineNumber + 1}
@@ -123,7 +127,7 @@ export const LineGutter = ({
             className={cn("gutter-decoration", decoration.className)}
             style={{
               position: "absolute",
-              right: "4px",
+              right: "2px", // Consistent spacing from right edge
               top: "50%",
               transform: "translateY(-50%)",
               zIndex: 3,

--- a/src/components/editor/rendering/line-with-content.tsx
+++ b/src/components/editor/rendering/line-with-content.tsx
@@ -15,8 +15,7 @@ interface LineWithContentProps {
 export const LineWithContent = memo<LineWithContentProps>(
   ({ lineNumber, showLineNumbers, gutterWidth, lineHeight, isSelected }) => {
     const content = useEditorViewStore((state) => state.lines[lineNumber]);
-    const tokens =
-      useEditorViewStore((state) => state.lineTokens.get(lineNumber)) ?? [];
+    const tokens = useEditorViewStore((state) => state.lineTokens.get(lineNumber)) ?? [];
     const decorations = useEditorDecorationsStore((state) =>
       state.getDecorationsForLine(lineNumber),
     );
@@ -37,7 +36,7 @@ export const LineWithContent = memo<LineWithContentProps>(
         <LineGutter
           lineNumber={lineNumber}
           showLineNumbers={showLineNumbers}
-          gutterWidth={gutterWidth}
+          gutterWidth={showLineNumbers ? gutterWidth : 16}
           decorations={decorations}
         />
         <div

--- a/src/components/editor/rendering/line-with-content.tsx
+++ b/src/components/editor/rendering/line-with-content.tsx
@@ -15,7 +15,8 @@ interface LineWithContentProps {
 export const LineWithContent = memo<LineWithContentProps>(
   ({ lineNumber, showLineNumbers, gutterWidth, lineHeight, isSelected }) => {
     const content = useEditorViewStore((state) => state.lines[lineNumber]);
-    const tokens = useEditorViewStore((state) => state.lineTokens.get(lineNumber)) ?? [];
+    const tokens =
+      useEditorViewStore((state) => state.lineTokens.get(lineNumber)) ?? [];
     const decorations = useEditorDecorationsStore((state) =>
       state.getDecorationsForLine(lineNumber),
     );
@@ -36,7 +37,7 @@ export const LineWithContent = memo<LineWithContentProps>(
         <LineGutter
           lineNumber={lineNumber}
           showLineNumbers={showLineNumbers}
-          gutterWidth={showLineNumbers ? gutterWidth : 16}
+          gutterWidth={gutterWidth}
           decorations={decorations}
         />
         <div

--- a/src/constants/editor-constants.ts
+++ b/src/constants/editor-constants.ts
@@ -14,7 +14,8 @@ export const EDITOR_CONSTANTS = {
   // Gutter
   MIN_GUTTER_WIDTH: 40,
   GUTTER_CHAR_WIDTH: 8,
-  GUTTER_PADDING: 16,
+  GUTTER_PADDING: 24, // Increased to account for git indicators (8px left + 8px right + 8px spacing)
+  GIT_INDICATOR_WIDTH: 8, // Space reserved for git gutter indicators on the left
 
   // Z-index layers
   Z_INDEX: {

--- a/src/hooks/use-editor-layout.ts
+++ b/src/hooks/use-editor-layout.ts
@@ -16,9 +16,10 @@ export function useEditorLayout() {
       ? Math.max(
           EDITOR_CONSTANTS.MIN_GUTTER_WIDTH,
           String(lineCount).length * EDITOR_CONSTANTS.GUTTER_CHAR_WIDTH +
-            EDITOR_CONSTANTS.GUTTER_PADDING,
+            EDITOR_CONSTANTS.GUTTER_PADDING +
+            EDITOR_CONSTANTS.GIT_INDICATOR_WIDTH,
         )
-      : 0;
+      : EDITOR_CONSTANTS.GIT_INDICATOR_WIDTH + 16; // Always reserve space for git indicators even without line numbers
 
     return {
       lineHeight,

--- a/src/hooks/use-git-gutter.ts
+++ b/src/hooks/use-git-gutter.ts
@@ -170,20 +170,14 @@ export function useGitGutter({
         let relativePath = filePath;
         if (relativePath.startsWith(rootFolderPath)) {
           relativePath = relativePath.slice(rootFolderPath.length);
-          if (relativePath.startsWith("/"))
-            relativePath = relativePath.slice(1);
+          if (relativePath.startsWith("/")) relativePath = relativePath.slice(1);
         }
 
         console.log(`[GitGutter] Getting diff for ${relativePath}`);
 
         // Use content-based diff for live typing, regular diff for file system events
         const diff = useContentDiff
-          ? await getFileDiffAgainstContent(
-              rootFolderPath,
-              relativePath,
-              content,
-              "head",
-            )
+          ? await getFileDiffAgainstContent(rootFolderPath, relativePath, content, "head")
           : await getFileDiff(rootFolderPath, relativePath, false, content);
         console.log(`[GitGutter] Got diff result:`, {
           hasDiff: !!diff,
@@ -194,13 +188,9 @@ export function useGitGutter({
 
         if (!diff || diff.is_binary || diff.is_image) {
           // Clear decorations for binary/image files
-          console.log(
-            `[GitGutter] Clearing decorations - no diff or binary/image file`,
-          );
+          console.log(`[GitGutter] Clearing decorations - no diff or binary/image file`);
           const decorationsStore = useEditorDecorationsStore.getState();
-          gitDecorationIdsRef.current.forEach((id) =>
-            decorationsStore.removeDecoration(id),
-          );
+          gitDecorationIdsRef.current.forEach((id) => decorationsStore.removeDecoration(id));
           gitDecorationIdsRef.current = [];
           return;
         }
@@ -220,20 +210,11 @@ export function useGitGutter({
         console.error(`[GitGutter] Error updating git gutter:`, error);
         // Clear decorations on error
         const decorationsStore = useEditorDecorationsStore.getState();
-        gitDecorationIdsRef.current.forEach((id) =>
-          decorationsStore.removeDecoration(id),
-        );
+        gitDecorationIdsRef.current.forEach((id) => decorationsStore.removeDecoration(id));
         gitDecorationIdsRef.current = [];
       }
     },
-    [
-      enabled,
-      filePath,
-      rootFolderPath,
-      processGitDiff,
-      applyGitDecorations,
-      content,
-    ],
+    [enabled, filePath, rootFolderPath, processGitDiff, applyGitDecorations, content],
   );
 
   // Debounced update function for content changes
@@ -330,10 +311,7 @@ export function useGitGutter({
 
   // Return current git changes for external use if needed
   return {
-    updateGitGutter: useCallback(
-      () => updateGitGutter(false),
-      [updateGitGutter],
-    ),
+    updateGitGutter: useCallback(() => updateGitGutter(false), [updateGitGutter]),
     clearGitGutter: useCallback(() => {
       const decorationsStore = useEditorDecorationsStore.getState();
       gitDecorationIdsRef.current.forEach((id) =>

--- a/src/hooks/use-git-gutter.ts
+++ b/src/hooks/use-git-gutter.ts
@@ -16,11 +16,7 @@ interface ProcessedGitChanges {
   deletedLines: Map<number, number>; // line number -> count
 }
 
-export function useGitGutter({
-  filePath,
-  content,
-  enabled = true,
-}: GitGutterHookOptions) {
+export function useGitGutter({ filePath, content, enabled = true }: GitGutterHookOptions) {
   const gitDecorationIdsRef = useRef<string[]>([]);
   const lastDiffRef = useRef<GitDiff | null>(null);
   const lastContentHashRef = useRef<string>("");
@@ -115,16 +111,10 @@ export function useGitGutter({
     const decorationsStore = useEditorDecorationsStore.getState();
 
     // Clear existing decorations
-    gitDecorationIdsRef.current.forEach((id) =>
-      decorationsStore.removeDecoration(id),
-    );
+    gitDecorationIdsRef.current.forEach((id) => decorationsStore.removeDecoration(id));
     gitDecorationIdsRef.current = [];
 
-    const addMarker = (
-      lineNumber: number,
-      className: string,
-      content: string = " ",
-    ) => {
+    const addMarker = (lineNumber: number, className: string, content: string = " ") => {
       const id = decorationsStore.addDecoration({
         type: "gutter",
         className,
@@ -237,9 +227,7 @@ export function useGitGutter({
     return () => {
       // Clear decorations when component unmounts or file changes
       const decorationsStore = useEditorDecorationsStore.getState();
-      gitDecorationIdsRef.current.forEach((id) =>
-        decorationsStore.removeDecoration(id),
-      );
+      gitDecorationIdsRef.current.forEach((id) => decorationsStore.removeDecoration(id));
       gitDecorationIdsRef.current = [];
     };
   }, [filePath, rootFolderPath]);
@@ -288,20 +276,11 @@ export function useGitGutter({
 
     // Listen for file reloads and git status updates
     window.addEventListener("file-reloaded", handleFileReload as EventListener);
-    window.addEventListener(
-      "git-status-updated",
-      handleGitStatusUpdate as EventListener,
-    );
+    window.addEventListener("git-status-updated", handleGitStatusUpdate as EventListener);
 
     return () => {
-      window.removeEventListener(
-        "file-reloaded",
-        handleFileReload as EventListener,
-      );
-      window.removeEventListener(
-        "git-status-updated",
-        handleGitStatusUpdate as EventListener,
-      );
+      window.removeEventListener("file-reloaded", handleFileReload as EventListener);
+      window.removeEventListener("git-status-updated", handleGitStatusUpdate as EventListener);
 
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
@@ -314,9 +293,7 @@ export function useGitGutter({
     updateGitGutter: useCallback(() => updateGitGutter(false), [updateGitGutter]),
     clearGitGutter: useCallback(() => {
       const decorationsStore = useEditorDecorationsStore.getState();
-      gitDecorationIdsRef.current.forEach((id) =>
-        decorationsStore.removeDecoration(id),
-      );
+      gitDecorationIdsRef.current.forEach((id) => decorationsStore.removeDecoration(id));
       gitDecorationIdsRef.current = [];
     }, []),
   };

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -237,12 +237,7 @@ export const getFileDiffAgainstContent = async (
 ): Promise<GitDiff | null> => {
   try {
     // Check cache first using a unique key for content-based diffs
-    const cached = gitDiffCache.get(
-      repoPath,
-      filePath,
-      base === "index",
-      content,
-    );
+    const cached = gitDiffCache.get(repoPath, filePath, base === "index", content);
     if (cached) {
       return cached;
     }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -42,9 +42,7 @@ export interface GitDiff {
   new_blob_base64?: string;
 }
 
-export const getGitStatus = async (
-  repoPath: string,
-): Promise<GitStatus | null> => {
+export const getGitStatus = async (repoPath: string): Promise<GitStatus | null> => {
   try {
     const status = await tauriInvoke<GitStatus>("git_status", { repoPath });
     return status;
@@ -54,10 +52,7 @@ export const getGitStatus = async (
   }
 };
 
-export const stageFile = async (
-  repoPath: string,
-  filePath: string,
-): Promise<boolean> => {
+export const stageFile = async (repoPath: string, filePath: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_add", { repoPath, filePath });
     return true;
@@ -67,10 +62,7 @@ export const stageFile = async (
   }
 };
 
-export const unstageFile = async (
-  repoPath: string,
-  filePath: string,
-): Promise<boolean> => {
+export const unstageFile = async (repoPath: string, filePath: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_reset", { repoPath, filePath });
     return true;
@@ -100,10 +92,7 @@ export const unstageAllFiles = async (repoPath: string): Promise<boolean> => {
   }
 };
 
-export const commitChanges = async (
-  repoPath: string,
-  message: string,
-): Promise<boolean> => {
+export const commitChanges = async (repoPath: string, message: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_commit", { repoPath, message });
     return true;
@@ -113,11 +102,7 @@ export const commitChanges = async (
   }
 };
 
-export const getGitLog = async (
-  repoPath: string,
-  limit = 50,
-  skip = 0,
-): Promise<GitCommit[]> => {
+export const getGitLog = async (repoPath: string, limit = 50, skip = 0): Promise<GitCommit[]> => {
   try {
     const commits = await tauriInvoke<GitCommit[]>("git_log", {
       repoPath,
@@ -185,10 +170,7 @@ export const createBranch = async (
   }
 };
 
-export const deleteBranch = async (
-  repoPath: string,
-  branchName: string,
-): Promise<boolean> => {
+export const deleteBranch = async (repoPath: string, branchName: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_delete_branch", { repoPath, branchName });
     return true;
@@ -305,10 +287,7 @@ export const pullChanges = async (
   }
 };
 
-export const fetchChanges = async (
-  repoPath: string,
-  remote?: string,
-): Promise<boolean> => {
+export const fetchChanges = async (repoPath: string, remote?: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_fetch", { repoPath, remote });
     return true;
@@ -328,10 +307,7 @@ export const discardAllChanges = async (repoPath: string): Promise<boolean> => {
   }
 };
 
-export const discardFileChanges = async (
-  repoPath: string,
-  filePath: string,
-): Promise<boolean> => {
+export const discardFileChanges = async (repoPath: string, filePath: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_discard_file_changes", { repoPath, filePath });
     return true;
@@ -368,11 +344,7 @@ export const getRemotes = async (repoPath: string): Promise<GitRemote[]> => {
   }
 };
 
-export const addRemote = async (
-  repoPath: string,
-  name: string,
-  url: string,
-): Promise<boolean> => {
+export const addRemote = async (repoPath: string, name: string, url: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_add_remote", { repoPath, name, url });
     return true;
@@ -382,10 +354,7 @@ export const addRemote = async (
   }
 };
 
-export const removeRemote = async (
-  repoPath: string,
-  name: string,
-): Promise<boolean> => {
+export const removeRemote = async (repoPath: string, name: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_remove_remote", { repoPath, name });
     return true;
@@ -431,10 +400,7 @@ export const createStash = async (
   }
 };
 
-export const applyStash = async (
-  repoPath: string,
-  stashIndex: number,
-): Promise<boolean> => {
+export const applyStash = async (repoPath: string, stashIndex: number): Promise<boolean> => {
   try {
     await tauriInvoke("git_apply_stash", { repoPath, stashIndex });
     return true;
@@ -444,10 +410,7 @@ export const applyStash = async (
   }
 };
 
-export const popStash = async (
-  repoPath: string,
-  stashIndex?: number,
-): Promise<boolean> => {
+export const popStash = async (repoPath: string, stashIndex?: number): Promise<boolean> => {
   try {
     await tauriInvoke("git_pop_stash", { repoPath, stashIndex });
     return true;
@@ -457,10 +420,7 @@ export const popStash = async (
   }
 };
 
-export const dropStash = async (
-  repoPath: string,
-  stashIndex: number,
-): Promise<boolean> => {
+export const dropStash = async (repoPath: string, stashIndex: number): Promise<boolean> => {
   try {
     await tauriInvoke("git_drop_stash", { repoPath, stashIndex });
     return true;
@@ -502,10 +462,7 @@ export const createTag = async (
   }
 };
 
-export const deleteTag = async (
-  repoPath: string,
-  name: string,
-): Promise<boolean> => {
+export const deleteTag = async (repoPath: string, name: string): Promise<boolean> => {
   try {
     await tauriInvoke("git_delete_tag", { repoPath, name });
     return true;
@@ -520,10 +477,7 @@ export interface GitHunk {
   lines: GitDiffLine[];
 }
 
-export const stageHunk = async (
-  repoPath: string,
-  hunk: GitHunk,
-): Promise<boolean> => {
+export const stageHunk = async (repoPath: string, hunk: GitHunk): Promise<boolean> => {
   try {
     await tauriInvoke("git_stage_hunk", { repoPath, hunk });
     return true;
@@ -533,10 +487,7 @@ export const stageHunk = async (
   }
 };
 
-export const unstageHunk = async (
-  repoPath: string,
-  hunk: GitHunk,
-): Promise<boolean> => {
+export const unstageHunk = async (repoPath: string, hunk: GitHunk): Promise<boolean> => {
   try {
     await tauriInvoke("git_unstage_hunk", { repoPath, hunk });
     return true;


### PR DESCRIPTION
# Pull Request

Add Git gutter indicators to the editor to visualize added, modified, and deleted lines relative to the current repository HEAD.

## Description
- Compute diff using getFileDiff(rootFolderPath, relativePath, false) and skip binary/image files and diff:// buffers.
- Apply decorations via useEditorDecorationsStore with type: "gutter" and class names:
- `LineGutter`z splits git vs. other decorations and positions git bars on the far left.

## Screenshots/Videos

<img width="1470" height="956" alt="Screenshot 2025-08-08 at 8 13 36 AM" src="https://github.com/user-attachments/assets/41975f11-f7f7-443d-b7de-014abd6b23f8" />

## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes # Fixes #


