### PR TITLE
Sync terminal themes with global theme changes

### DIFF
--- a/src/components/terminal/terminal.tsx
+++ b/src/components/terminal/terminal.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/utils/cn";
 import { TerminalSearch } from "./terminal-search";
 import "@xterm/xterm/css/xterm.css";
 import "./terminal.css";
+import { themeRegistry } from "@/extensions/themes";
 
 interface XtermTerminalProps {
   sessionId: string;
@@ -444,10 +445,23 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
       }
     });
 
+    const unlistenThemeChange = themeRegistry.onThemeChange(() => {
+      if (xtermRef.current) {
+        xtermRef.current.options.theme = getTerminalTheme();
+        setTimeout(() => {
+          if (xtermRef.current) {
+            xtermRef.current.refresh(0, xtermRef.current.rows - 1);
+            fitAddonRef.current?.fit();
+          }
+        }, 10);
+      }
+    });
+
     return () => {
       unlistenOutput.then((fn) => fn());
       unlistenError.then((fn) => fn());
       unlistenClosed.then((fn) => fn());
+      unlistenThemeChange();
     };
   }, [sessionId, isInitialized, connectionId]);
 

--- a/src/settings/components/settings-dialog.tsx
+++ b/src/settings/components/settings-dialog.tsx
@@ -77,7 +77,7 @@ const SettingsDialog = ({ isOpen, onClose }: SettingsDialogProps) => {
       <div
         className={cn(
           "-translate-x-1/2 -translate-y-1/2 fixed top-1/2 left-1/2 z-[9999] transform",
-          "h-[600px] max-h-[90vh] w-[800px] max-w-[90vw]",
+          "h-[600px] max-h-[90vh] w-[800px] max-w-[90vw] overflow-hidden",
           "rounded-lg border border-border bg-primary-bg shadow-xl",
           "flex flex-col",
         )}


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- Update terminal theme when global theme change.
- Fix setting-dialog style
<img width="307" alt="CleanShot 2025-08-13 at 00 08 49" src="https://github.com/user-attachments/assets/b2677f28-7d64-4596-acdb-f0a03fc69405" />


## Screenshots/Videos

<table>
<tr>
 <td>
Before
 <td>
After
<td>

<tr>
 <td>

https://github.com/user-attachments/assets/25e38054-bc07-48c9-bf2b-4d6f429bddae


 <td>

https://github.com/user-attachments/assets/174d81ec-4255-4816-bd33-a11a6cc125bd





</table>


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes # Fixes #


