### PR TITLE
Implement cursor position restoration when switching files

### DIFF
--- a/src/components/editor/core/text-editor.tsx
+++ b/src/components/editor/core/text-editor.tsx
@@ -35,6 +35,7 @@ export function TextEditor() {
   const lines = useEditorViewStore.use.lines();
   const { getContent } = useEditorViewStore.use.actions();
   const { updateBufferContent } = useBufferStore.use.actions();
+  const { setCursorVisibility, restorePositionForFile } = useEditorCursorStore.use.actions();
   const activeBufferId = useBufferStore.use.activeBufferId();
   const { onChange, disabled, filePath, editorRef } = useEditorInstanceStore();
   const { setViewportHeight } = useEditorLayoutStore.use.actions();
@@ -324,6 +325,17 @@ export function TextEditor() {
     }
   }, [lines, setCursorPosition, setSelection]);
 
+  // Handle textarea blur event
+  const handleTextareaBlur = useCallback(() => {
+    setContextMenu({ isOpen: false, position: { x: 0, y: 0 } });
+    setCursorVisibility(false);
+  }, [setContextMenu, setCursorVisibility]);
+
+  // Handle textarea focus event
+  const handleTextareaFocus = useCallback(() => {
+    setCursorVisibility(true);
+  }, [setCursorVisibility]);
+
   useEffect(() => {
     const decorationsChanged =
       searchDecorations.length !== previousSearchDecorationsRef.current.length ||
@@ -366,22 +378,10 @@ export function TextEditor() {
     return () => {
       document.removeEventListener("selectionchange", handleDocumentSelectionChange);
     };
-  });
+  }, [handleSelectionChange]);
 
   // Focus textarea on mount and setup extension system
   useEffect(() => {
-    if (textareaRef.current && !disabled) {
-      textareaRef.current.focus();
-      // Delay setting selection to ensure content is loaded
-      setTimeout(() => {
-        if (textareaRef.current) {
-          textareaRef.current.selectionStart = 0;
-          textareaRef.current.selectionEnd = 0;
-          handleSelectionChange();
-        }
-      }, 0);
-    }
-
     // Set textarea ref in editor API
     editorAPI.setTextareaRef(textareaRef.current);
 
@@ -449,15 +449,32 @@ export function TextEditor() {
     }
   }, [filePath]);
 
-  // Reset cursor position when switching to a new file
-  useEffect(() => {
-    // Only reset cursor when activeBufferId changes (switching files)
-    if (textareaRef.current && content !== "") {
-      textareaRef.current.selectionStart = 0;
-      textareaRef.current.selectionEnd = 0;
+  const restoreCursorPosition = useCallback(
+    (bufferId: string) => {
+      if (!textareaRef.current) return;
+
+      const restored = restorePositionForFile(bufferId);
+
+      if (restored) {
+        const cursorPosition = useEditorCursorStore.getState().cursorPosition;
+        textareaRef.current.selectionStart = textareaRef.current.selectionEnd =
+          cursorPosition.offset;
+      } else {
+        textareaRef.current.selectionStart = 0;
+        textareaRef.current.selectionEnd = 0;
+      }
+
       handleSelectionChange();
+    },
+    [content, handleSelectionChange],
+  );
+
+  // Restore cursor position when switching to a new file
+  useEffect(() => {
+    if (activeBufferId) {
+      restoreCursorPosition(activeBufferId);
     }
-  }, [activeBufferId]); // Only depend on activeBufferId, not content
+  }, [activeBufferId, restoreCursorPosition]);
 
   // Update editor API by subscribing to cursor store changes
   useEffect(() => {
@@ -470,16 +487,12 @@ export function TextEditor() {
     return unsubscribe;
   }, []);
 
-  // Update textarea ref in editor API when it changes
   useEffect(() => {
+    // Update textarea ref in editor API when it changes
     editorAPI.setTextareaRef(textareaRef.current);
-  }, []);
 
-  // Update viewport ref in editor API when it changes
-  useEffect(() => {
-    if (viewportRef.current) {
-      editorAPI.setViewportRef(viewportRef.current);
-    }
+    // Update viewport ref in editor API when it changes
+    viewportRef.current && editorAPI.setViewportRef(viewportRef.current);
   }, []);
 
   // Update viewport height when container size changes
@@ -916,11 +929,12 @@ export function TextEditor() {
         value={content}
         onChange={handleTextareaChange}
         onInput={handleTextareaChange}
+        onBlur={handleTextareaBlur}
+        onFocus={handleTextareaFocus}
         onKeyDown={handleKeyDown}
         onSelect={handleSelectionChange}
         onKeyUp={handleSelectionChange}
         onMouseDown={handleSelectionChange}
-        onMouseMove={handleSelectionChange}
         onMouseUp={handleSelectionChange}
         onContextMenu={handleContextMenu}
         onScroll={() => {

--- a/src/components/editor/overlays/cursor.tsx
+++ b/src/components/editor/overlays/cursor.tsx
@@ -5,16 +5,14 @@ import { useEditorCursorStore } from "@/stores/editor-cursor-store";
 import { useEditorLayoutStore } from "@/stores/editor-layout-store";
 import { useEditorSettingsStore } from "@/stores/editor-settings-store";
 
-interface CursorRendererProps {
-  visible?: boolean;
-}
-
-export function Cursor({ visible = true }: CursorRendererProps) {
+export function Cursor() {
   const cursorRef = useRef<HTMLDivElement>(null);
   const movementTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const { scrollTop, scrollLeft } = useEditorLayoutStore();
   const { lineHeight, charWidth, gutterWidth } = useEditorLayout();
   const showLineNumbers = useEditorSettingsStore.use.lineNumbers();
+  const visible = useEditorCursorStore((state) => state.cursorVisible);
+
   // Update position without re-rendering
   useEffect(() => {
     if (!cursorRef.current || !visible) return;

--- a/src/components/tab-bar/tab-bar.tsx
+++ b/src/components/tab-bar/tab-bar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSettingsStore } from "@/settings/store";
 import { useBufferStore } from "@/stores/buffer-store";
+import { useEditorCursorStore } from "@/stores/editor-cursor-store";
 import { useSidebarStore } from "@/stores/sidebar-store";
 import type { Buffer } from "@/types/buffer";
 import TabBarItem from "./tab-bar-item";
@@ -67,6 +68,7 @@ const TabBar = ({ paneId }: TabBarProps) => {
   const tabBarRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef<(HTMLDivElement | null)[]>([]);
   const dragStateRef = useRef(dragState);
+  const { clearPositionCache } = useEditorCursorStore.getState().actions;
 
   useEffect(() => {
     dragStateRef.current = dragState;
@@ -423,7 +425,11 @@ const TabBar = ({ paneId }: TabBarProps) => {
                 onContextMenu={(e) => handleContextMenu(e, buffer)}
                 onDragStart={(e) => handleDragStart(e, index)}
                 onDragEnd={handleDragEnd}
-                handleTabClose={handleTabClose}
+                handleTabClose={(id) => {
+                  handleTabClose(id);
+                  // Clear cached position for this buffer
+                  clearPositionCache(id);
+                }}
               />
             );
           })}

--- a/src/stores/editor-cursor-store.ts
+++ b/src/stores/editor-cursor-store.ts
@@ -2,28 +2,103 @@ import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { createSelectors } from "@/utils/zustand-selectors";
 import type { Position, Range } from "../types/editor-types";
+import { useBufferStore } from "./buffer-store";
 
 interface EditorCursorState {
   cursorPosition: Position;
   selection?: Range;
   desiredColumn?: number;
   actions: EditorCursorActions;
+  cursorVisible: boolean;
 }
 
 interface EditorCursorActions {
   setCursorPosition: (position: Position) => void;
   setSelection: (selection?: Range) => void;
   setDesiredColumn: (column?: number) => void;
+  setCursorVisibility: (visible: boolean) => void;
+  getCachedPosition: (filePath: string) => Position | null;
+  clearPositionCache: (filePath?: string) => void;
+  restorePositionForFile: (bufferId: string) => boolean;
 }
+
+class PositionCacheManager {
+  private cache = new Map<string, Position>();
+  private readonly MAX_CACHE_SIZE = 50;
+
+  set(bufferId: string, position: Position): void {
+    const cachedPosition = this.cache.get(bufferId);
+    if (cachedPosition && this.positionsEqual(cachedPosition, position)) {
+      return;
+    }
+
+    if (this.cache.size >= this.MAX_CACHE_SIZE && !this.cache.has(bufferId)) {
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey) {
+        this.cache.delete(firstKey);
+      }
+    }
+
+    this.cache.set(bufferId, { ...position });
+  }
+
+  get(bufferId: string): Position | null {
+    const cachedPosition = this.cache.get(bufferId);
+    if (!cachedPosition) return null;
+
+    return { ...cachedPosition };
+  }
+
+  clear(bufferId?: string): void {
+    if (bufferId) {
+      this.cache.delete(bufferId);
+    } else {
+      this.cache.clear();
+    }
+  }
+
+  private positionsEqual(pos1: Position, pos2: Position): boolean {
+    return pos1.line === pos2.line && pos1.column === pos2.column && pos1.offset === pos2.offset;
+  }
+}
+
+const positionCache = new PositionCacheManager();
 
 export const useEditorCursorStore = createSelectors(
   create<EditorCursorState>()(
     subscribeWithSelector((set, _get) => ({
       cursorPosition: { line: 0, column: 0, offset: 0 },
+      cursorVisible: false,
       actions: {
-        setCursorPosition: (position) => set({ cursorPosition: position }),
+        setCursorPosition: (position) => {
+          const activeBufferId = useBufferStore.getState().activeBufferId;
+          if (activeBufferId) {
+            positionCache.set(activeBufferId, position);
+          }
+
+          set({ cursorPosition: position });
+        },
         setSelection: (selection) => set({ selection }),
         setDesiredColumn: (column) => set({ desiredColumn: column }),
+        setCursorVisibility: (visible) =>
+          set({
+            cursorVisible: visible,
+          }),
+        getCachedPosition: (bufferId) => {
+          return positionCache.get(bufferId);
+        },
+        clearPositionCache: (bufferId) => {
+          positionCache.clear(bufferId);
+        },
+        restorePositionForFile: (bufferId) => {
+          const cachedPosition = positionCache.get(bufferId);
+
+          if (cachedPosition) {
+            set({ cursorPosition: cachedPosition });
+            return true;
+          }
+          return false;
+        },
       },
     })),
   ),


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->



- Hide the cursor when the textarea loses focus (blur), and display it when focused.
- Save the cursor position when switching tabs and restore it upon returning.

## Screenshots/Videos


https://github.com/user-attachments/assets/9b1c0f56-abcf-4c54-a88c-d7fbb70be5ee


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes # Fixes #


