### PR TITLE
Fix: extensions button not styled when active in sidebar #244

### DIFF
--- a/src/components/layout/main-sidebar.tsx
+++ b/src/components/layout/main-sidebar.tsx
@@ -41,6 +41,7 @@ export const MainSidebar = () => {
     isRemoteViewActive,
     setActiveView,
     setProjectNameMenu,
+    isExtensionsViewActive,
   } = useUIState();
   const { getProjectName } = useProjectStore();
 
@@ -107,6 +108,7 @@ export const MainSidebar = () => {
         isGitViewActive={isGitViewActive}
         isSearchViewActive={isSearchViewActive}
         isRemoteViewActive={isRemoteViewActive}
+        isExtensionsViewActive={isExtensionsViewActive}
         coreFeatures={settings.coreFeatures}
         onViewChange={setActiveView}
         onOpenExtensions={onOpenExtensions}

--- a/src/components/layout/sidebar-pane-selector.tsx
+++ b/src/components/layout/sidebar-pane-selector.tsx
@@ -6,8 +6,9 @@ interface SidebarPaneSelectorProps {
   isGitViewActive: boolean;
   isSearchViewActive: boolean;
   isRemoteViewActive: boolean;
+  isExtensionsViewActive: boolean;
   coreFeatures: CoreFeaturesState;
-  onViewChange: (view: "files" | "git" | "search" | "remote") => void;
+  onViewChange: (view: "files" | "git" | "search" | "remote" | "extensions") => void;
   onOpenExtensions: () => void;
 }
 
@@ -15,11 +16,13 @@ export const SidebarPaneSelector = ({
   isGitViewActive,
   isSearchViewActive,
   isRemoteViewActive,
+  isExtensionsViewActive,
   coreFeatures,
   onViewChange,
   onOpenExtensions,
 }: SidebarPaneSelectorProps) => {
-  const isFilesActive = !isGitViewActive && !isSearchViewActive && !isRemoteViewActive;
+  const isFilesActive =
+    !isGitViewActive && !isSearchViewActive && !isRemoteViewActive && !isExtensionsViewActive;
 
   return (
     <div className="flex gap-0.5 border-border border-b bg-secondary-bg p-1.5">
@@ -90,10 +93,18 @@ export const SidebarPaneSelector = ({
       )}
 
       <Button
-        onClick={onOpenExtensions}
+        onClick={() => {
+          onViewChange("extensions");
+          onOpenExtensions();
+        }}
         variant="ghost"
         size="sm"
-        className="flex h-6 w-6 items-center justify-center rounded p-0 text-text-lighter text-xs hover:bg-hover hover:text-text"
+        data-active={isExtensionsViewActive}
+        className={`flex h-6 w-6 items-center justify-center rounded p-0 text-xs ${
+          isExtensionsViewActive
+            ? "bg-selected text-text"
+            : "text-text-lighter hover:bg-hover hover:text-text"
+        }`}
         title="Extensions"
       >
         <Package size={14} />

--- a/src/stores/ui-state-store.ts
+++ b/src/stores/ui-state-store.ts
@@ -13,6 +13,7 @@ const initialState = {
   isGitViewActive: false,
   isSearchViewActive: false,
   isRemoteViewActive: false,
+  isExtensionsViewActive: false,
   isGitHubCopilotSettingsVisible: false,
 
   // Dialog States
@@ -61,11 +62,12 @@ export const useUIState = create(
 
     setProjectNameMenu: (v: { x: number; y: number } | null) => set({ projectNameMenu: v }),
 
-    setActiveView: (view: "files" | "git" | "search" | "remote") => {
+    setActiveView: (view: "files" | "git" | "search" | "remote" | "extensions") => {
       set({
         isGitViewActive: view === "git",
         isSearchViewActive: view === "search",
         isRemoteViewActive: view === "remote",
+        isExtensionsViewActive: view === "extensions",
       });
     },
 


### PR DESCRIPTION
# Pull Request

This PR fixes an issue where the Extensions button in the sidebar was not properly styled when active

## Description

- Added Extensions view state tracking: Extended the UI state store to include isExtensionsViewActive to properly
  track when the Extensions view is active
- Updated SidebarPaneSelector component:
    - Added isExtensionsViewActive prop to track extensions view state
    - Modified the Extensions button click handler to set the active view state
- Enhanced main sidebar integration: Connected the extensions view state to the sidebar pane selector

## Screenshots/Videos

<img width="1270" height="601" alt="image" src="https://github.com/user-attachments/assets/d8c12046-db76-4ecc-814b-67044ce83066" />



## Related Issues

Fixes #244  


