### PR TITLE
Do not run CI workflows in forks

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -13,6 +13,8 @@ concurrency:
 
 jobs:
   check:
+    # Don't run on forks
+    if: github.repository == 'athasdev/athas'
     name: check format, types, and lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ env:
 
 jobs:
   check:
+    # Don't run on forks
+    if: github.repository == 'athasdev/athas'
     name: check format and cargo check
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->
Only run CI workflows in `athasdev/athas`. This will prevent them running on forks every time you update your branches from upstream.