### PR TITLE
Enhance remote connection handling

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -10,6 +10,7 @@
     "core:window:default",
     "core:window:allow-start-dragging",
     "core:window:allow-close",
+    "core:window:allow-destroy",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-internal-toggle-maximize",

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -1,4 +1,6 @@
-use tauri::{Emitter, WebviewUrl, WebviewWindowBuilder, command};
+use tauri::{
+   Emitter, Manager, TitleBarStyle, UserAttentionType, WebviewUrl, WebviewWindowBuilder, command,
+};
 
 #[command]
 pub async fn create_remote_window(
@@ -8,17 +10,25 @@ pub async fn create_remote_window(
 ) -> Result<(), String> {
    let window_label = format!("remote-{connection_id}");
 
+   // Check if window already exists
+   if let Some(existing_window) = app.get_webview_window(&window_label) {
+      // Window exists, just focus it and return
+      let _ = existing_window.set_focus();
+      return Ok(());
+   }
+
    let url = format!("index.html?remote={connection_id}");
    let window = WebviewWindowBuilder::new(&app, &window_label, WebviewUrl::App(url.into()))
-      .title(format!("Remote: {connection_name}"))
+      .hidden_title(true)
+      .title_bar_style(TitleBarStyle::Overlay)
+      .transparent(true)
       .inner_size(1200.0, 800.0)
       .min_inner_size(800.0, 600.0)
       .center()
-      .decorations(false)
-      .transparent(true)
-      .shadow(false)
       .build()
       .map_err(|e| format!("Failed to create window: {e}"))?;
+
+   let _ = window.request_user_attention(Some(UserAttentionType::Informational));
 
    #[cfg(target_os = "macos")]
    {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,7 +6,7 @@ use commands::*;
 use file_watcher::FileWatcher;
 use log::{debug, info};
 use lsp::LspManager;
-use ssh::{ssh_connect, ssh_disconnect, ssh_write_file};
+use ssh::{ssh_connect, ssh_disconnect, ssh_disconnect_only, ssh_write_file};
 use std::sync::Arc;
 use tauri::{Emitter, Manager};
 use tokio::sync::Mutex;
@@ -244,6 +244,7 @@ fn main() {
          // SSH commands
          ssh_connect,
          ssh_disconnect,
+         ssh_disconnect_only,
          ssh_write_file,
          // Claude commands
          start_claude_code,

--- a/src/components/layout/sidebar-pane-selector.tsx
+++ b/src/components/layout/sidebar-pane-selector.tsx
@@ -7,6 +7,7 @@ interface SidebarPaneSelectorProps {
   isSearchViewActive: boolean;
   isRemoteViewActive: boolean;
   isExtensionsViewActive: boolean;
+  isRemoteWindow: boolean;
   coreFeatures: CoreFeaturesState;
   onViewChange: (view: "files" | "git" | "search" | "remote" | "extensions") => void;
   onOpenExtensions: () => void;
@@ -17,6 +18,7 @@ export const SidebarPaneSelector = ({
   isSearchViewActive,
   isRemoteViewActive,
   isExtensionsViewActive,
+  isRemoteWindow,
   coreFeatures,
   onViewChange,
   onOpenExtensions,
@@ -75,7 +77,7 @@ export const SidebarPaneSelector = ({
         </Button>
       )}
 
-      {coreFeatures.remote && (
+      {coreFeatures.remote && !isRemoteWindow && (
         <Button
           onClick={() => onViewChange("remote")}
           variant="ghost"

--- a/src/components/remote/connection-dialog.tsx
+++ b/src/components/remote/connection-dialog.tsx
@@ -26,6 +26,7 @@ const ConnectionDialog = ({
     password: "",
     keyPath: "",
     type: "ssh",
+    saveCredentials: false,
   });
   const [showPassword, setShowPassword] = useState(false);
   const [isValidating, setIsValidating] = useState(false);
@@ -48,6 +49,7 @@ const ConnectionDialog = ({
           password: editingConnection.password || "",
           keyPath: editingConnection.keyPath || "",
           type: editingConnection.type,
+          saveCredentials: editingConnection.saveCredentials ?? false,
         });
       } else {
         setFormData({
@@ -58,6 +60,7 @@ const ConnectionDialog = ({
           password: "",
           keyPath: "",
           type: "ssh",
+          saveCredentials: false,
         });
       }
       setValidationStatus("idle");
@@ -290,6 +293,27 @@ const ConnectionDialog = ({
                 disabled={isValidating}
               />
             </div>
+
+            {/* Save Credentials Option */}
+            {formData.password && (
+              <div className="space-y-2">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={formData.saveCredentials}
+                    onChange={(e) => updateFormData({ saveCredentials: e.target.checked })}
+                    className="rounded border border-border bg-secondary-bg text-blue-500 focus:ring-blue-500"
+                    disabled={isValidating}
+                  />
+                  <span className="font-medium text-text text-xs">
+                    Save password for future connections
+                  </span>
+                </label>
+                <div className="text-text-lighter text-xs leading-relaxed">
+                  When unchecked, you'll need to enter the password each time you connect.
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Validation Status */}

--- a/src/components/remote/connection-list.tsx
+++ b/src/components/remote/connection-list.tsx
@@ -1,4 +1,4 @@
-import { Edit, FolderOpen, Plus, Server, Trash2, Wifi } from "lucide-react";
+import { Edit, FolderOpen, Plus, Server, Trash2, Wifi, WifiOff } from "lucide-react";
 import React, { useState } from "react";
 import { cn } from "@/utils/cn";
 import Button from "../ui/button";
@@ -34,7 +34,7 @@ const ConnectionList = ({
     const diffMs = now.getTime() - date.getTime();
     const diffMinutes = Math.floor(diffMs / (1000 * 60));
 
-    if (diffMinutes < 1) return "Just now";
+    if (diffMinutes < 1) return "just now";
     if (diffMinutes < 60) return `${diffMinutes}m ago`;
     if (diffMinutes < 1440) return `${Math.floor(diffMinutes / 60)}h ago`;
     return `${Math.floor(diffMinutes / 1440)}d ago`;
@@ -110,7 +110,7 @@ const ConnectionList = ({
 
                   {/* Connection Info - Clickable */}
                   <div className="min-w-0 flex-1">
-                    <div className="mb-1 flex flex-wrap items-center gap-2">
+                    <div className="mb-1 flex flex-wrap items-center gap-y-2">
                       <span
                         className="cursor-pointer truncate rounded px-1 py-0.5 font-medium text-sm text-text hover:bg-hover"
                         title="Click for options"
@@ -135,11 +135,11 @@ const ConnectionList = ({
                       >
                         {connection.name}
                       </span>
-                      <span className="flex-shrink-0 rounded bg-hover px-1.5 py-0.5 font-mono text-text-lighter text-xs">
+                      <span className="flex-shrink-0 rounded bg-hover px-1 font-mono text-text-lighter text-xs">
                         {connection.type.toUpperCase()}
                       </span>
                     </div>
-                    <div className="truncate text-text-lighter text-xs">
+                    <div className="mx-1 truncate text-text-lighter text-xs">
                       {connection.isConnected
                         ? "Connected"
                         : connection.lastConnected
@@ -148,18 +148,29 @@ const ConnectionList = ({
                     </div>
                   </div>
 
-                  {/* Connect/Browse Button Only */}
-                  <div className="flex flex-shrink-0 items-center">
+                  {/* Connect/Disconnect/Browse Buttons */}
+                  <div className="flex flex-shrink-0 items-center gap-1">
                     {connection.isConnected ? (
-                      <Button
-                        onClick={() => onFileSelect?.(`/remote/${connection.id}/`, true)}
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 w-6 cursor-pointer p-0"
-                        title="Browse Files"
-                      >
-                        <FolderOpen size={12} />
-                      </Button>
+                      <>
+                        <Button
+                          onClick={() => onFileSelect?.(`/remote/${connection.id}/`, true)}
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 cursor-pointer p-0"
+                          title="Browse Files"
+                        >
+                          <FolderOpen size={12} />
+                        </Button>
+                        <Button
+                          onClick={() => onConnect(connection.id)}
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 cursor-pointer p-0 text-text-lighter hover:text-red-400"
+                          title="Disconnect"
+                        >
+                          <WifiOff size={12} />
+                        </Button>
+                      </>
                     ) : (
                       <Button
                         onClick={() => onConnect(connection.id)}

--- a/src/components/remote/password-prompt-dialog.tsx
+++ b/src/components/remote/password-prompt-dialog.tsx
@@ -103,7 +103,7 @@ const PasswordPromptDialog = ({
         <div className="space-y-4 p-4">
           <div className="text-text-lighter text-xs leading-relaxed">
             Enter the password for <span className="font-medium text-text">{connection.name}</span>{" "}
-            ({connection.username}@64.***.**.72:{connection.port})
+            ({connection.username}@{connection.host}:{connection.port})
           </div>
 
           {/* Password Input */}

--- a/src/components/remote/password-prompt-dialog.tsx
+++ b/src/components/remote/password-prompt-dialog.tsx
@@ -1,0 +1,165 @@
+import { Eye, EyeOff, Lock, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { cn } from "@/utils/cn";
+import Button from "../ui/button";
+import type { RemoteConnection } from "./types";
+
+interface PasswordPromptDialogProps {
+  isOpen: boolean;
+  connection: RemoteConnection | null;
+  onClose: () => void;
+  onConnect: (connectionId: string, password: string) => Promise<void>;
+}
+
+const PasswordPromptDialog = ({
+  isOpen,
+  connection,
+  onClose,
+  onConnect,
+}: PasswordPromptDialogProps) => {
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    if (isOpen) {
+      setPassword("");
+      setShowPassword(false);
+      setIsConnecting(false);
+      setErrorMessage("");
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          onClose();
+        } else if (event.key === "Enter" && password.trim() && !isConnecting) {
+          handleConnect();
+        }
+      };
+
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen, password, isConnecting]);
+
+  if (!isOpen || !connection) return null;
+
+  const handleConnect = async () => {
+    if (!password.trim()) {
+      setErrorMessage("Password is required");
+      return;
+    }
+
+    setIsConnecting(true);
+    setErrorMessage("");
+
+    try {
+      await onConnect(connection.id, password);
+      onClose();
+    } catch (error) {
+      // Display a user-friendly error message
+      const rawError = error instanceof Error ? error.message : String(error);
+      let friendlyError = rawError;
+
+      if (rawError.includes("Authentication failed") || rawError.includes("username/password")) {
+        friendlyError = "Incorrect username or password. Please try again.";
+      } else if (rawError.includes("Connection refused") || rawError.includes("unreachable")) {
+        friendlyError = "Cannot connect to server. Check the host address and port.";
+      } else if (rawError.includes("timeout")) {
+        friendlyError = "Connection timed out. The server may be unavailable.";
+      } else if (rawError.includes("Host key verification failed")) {
+        friendlyError =
+          "Host key verification failed. The server's identity could not be verified.";
+      } else if (rawError.includes("Permission denied")) {
+        friendlyError = "Permission denied. Check your username and password.";
+      } else if (rawError.includes("No route to host")) {
+        friendlyError = "Cannot reach the server. Check your network connection.";
+      }
+
+      setErrorMessage(friendlyError || "Connection failed");
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden rounded-xl bg-black/50">
+      <div className="flex w-[400px] flex-col rounded-lg border border-border bg-primary-bg">
+        {/* Header */}
+        <div className="flex items-center justify-between border-border border-b p-4">
+          <div className="flex items-center gap-2">
+            <Lock size={16} className="text-text" />
+            <h3 className="font-mono text-sm text-text">Enter Password</h3>
+          </div>
+          <button onClick={onClose} className="text-text-lighter transition-colors hover:text-text">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="space-y-4 p-4">
+          <div className="text-text-lighter text-xs leading-relaxed">
+            Enter the password for <span className="font-medium text-text">{connection.name}</span>{" "}
+            ({connection.username}@64.***.**.72:{connection.port})
+          </div>
+
+          {/* Password Input */}
+          <div className="space-y-2">
+            <label htmlFor="password-prompt" className="font-medium text-text text-xs">
+              Password
+            </label>
+            <div className="relative">
+              <input
+                id="password-prompt"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  setErrorMessage("");
+                }}
+                placeholder="Enter password"
+                className={cn(
+                  "w-full rounded border border-border bg-secondary-bg",
+                  "px-3 py-2 pr-10 text-text text-xs placeholder-text-lighter",
+                  "focus:border-blue-500 focus:outline-none",
+                )}
+                disabled={isConnecting}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className={cn(
+                  "-translate-y-1/2 absolute top-1/2 right-3 transform",
+                  "text-text-lighter transition-colors hover:text-text",
+                )}
+              >
+                {showPassword ? <EyeOff size={14} /> : <Eye size={14} />}
+              </button>
+            </div>
+          </div>
+
+          {errorMessage && <div className="text-red-500 text-xs">{errorMessage}</div>}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 border-border border-t p-4">
+          <Button
+            onClick={handleConnect}
+            disabled={!password.trim() || isConnecting}
+            className="flex-1"
+          >
+            {isConnecting ? "Connecting..." : "Connect"}
+          </Button>
+          <Button onClick={onClose} variant="ghost" className="px-4">
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordPromptDialog;

--- a/src/components/remote/types.ts
+++ b/src/components/remote/types.ts
@@ -9,6 +9,7 @@ export interface RemoteConnection {
   type: "ssh" | "sftp";
   isConnected: boolean;
   lastConnected?: string;
+  saveCredentials?: boolean;
 }
 
 export interface RemoteConnectionFormData {
@@ -19,4 +20,5 @@ export interface RemoteConnectionFormData {
   password?: string;
   keyPath?: string;
   type: "ssh" | "sftp";
+  saveCredentials?: boolean;
 }

--- a/src/components/window/custom-title-bar.tsx
+++ b/src/components/window/custom-title-bar.tsx
@@ -22,7 +22,7 @@ const CustomTitleBar = ({
   const { getProjectName } = useProjectStore();
   const { settings, updateSetting } = useSettingsStore();
 
-  const projectName = getProjectName();
+  const [projectName, setProjectName] = useState<string>("");
   const [isMaximized, setIsMaximized] = useState(false);
   const [currentWindow, setCurrentWindow] = useState<any>(null);
   const [currentPlatform, setCurrentPlatform] = useState<string>(() => {
@@ -65,10 +65,19 @@ const CustomTitleBar = ({
       } catch (error) {
         console.error("Error checking maximized state:", error);
       }
+
+      // Get project name asynchronously
+      try {
+        const name = await getProjectName();
+        setProjectName(name);
+      } catch (error) {
+        console.error("Error getting project name:", error);
+        setProjectName("Explorer");
+      }
     };
 
     initWindow();
-  }, []);
+  }, [getProjectName]);
 
   const handleMinimize = async () => {
     try {

--- a/src/stores/project-store.ts
+++ b/src/stores/project-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { combine } from "zustand/middleware";
+import { connectionStore } from "@/utils/connection-store";
 
 export const useProjectStore = create(
   combine(
@@ -11,7 +12,20 @@ export const useProjectStore = create(
       setProjectName: (name: string) => set({ projectName: name }),
       setRootFolderPath: (path: string | undefined) => set({ rootFolderPath: path }),
 
-      getProjectName: () => {
+      getProjectName: async () => {
+        // Check if this is a remote window
+        const urlParams = new URLSearchParams(window.location.search);
+        const remoteConnectionId = urlParams.get("remote");
+
+        if (remoteConnectionId) {
+          try {
+            const connection = await connectionStore.getConnection(remoteConnectionId);
+            return connection ? `Remote: ${connection.name}` : "Remote";
+          } catch {
+            return "Remote";
+          }
+        }
+
         const { rootFolderPath } = get();
         if (!rootFolderPath) return "Explorer";
 

--- a/src/stores/sidebar-store.ts
+++ b/src/stores/sidebar-store.ts
@@ -4,8 +4,10 @@ import { createSelectors } from "@/utils/zustand-selectors";
 interface SidebarState {
   activePath?: string;
   isRemoteWindow: boolean;
+  remoteConnectionId?: string;
   remoteConnectionName?: string;
   updateActivePath: (path: string) => void;
+  setRemoteWindow: (isRemote: boolean, connectionName?: string, connectionId?: string) => void;
 }
 
 const useSidebarStoreBase = create<SidebarState>()((set) => ({
@@ -13,6 +15,13 @@ const useSidebarStoreBase = create<SidebarState>()((set) => ({
   activePath: undefined,
   updateActivePath: (path: string) => {
     set({ activePath: path });
+  },
+  setRemoteWindow: (isRemote: boolean, connectionName?: string, connectionId?: string) => {
+    set({
+      isRemoteWindow: isRemote,
+      remoteConnectionName: connectionName,
+      remoteConnectionId: connectionId,
+    });
   },
 }));
 

--- a/src/utils/connection-store.ts
+++ b/src/utils/connection-store.ts
@@ -1,0 +1,149 @@
+import { load } from "@tauri-apps/plugin-store";
+
+const CONNECTIONS_STORE = "remote-connections.json";
+const CREDENTIALS_STORE = "credentials.json";
+
+class ConnectionStore {
+  private connectionsStore: any = null;
+  private credentialsStore: any = null;
+
+  private async getConnectionsStore() {
+    if (!this.connectionsStore) {
+      this.connectionsStore = await load(CONNECTIONS_STORE, { autoSave: true });
+    }
+    return this.connectionsStore;
+  }
+
+  private async getCredentialsStore() {
+    if (!this.credentialsStore) {
+      this.credentialsStore = await load(CREDENTIALS_STORE, { autoSave: true });
+    }
+    return this.credentialsStore;
+  }
+
+  async saveConnection(connection: {
+    id: string;
+    name: string;
+    host: string;
+    port: number;
+    username: string;
+    password?: string;
+    keyPath?: string;
+    type: "ssh" | "sftp";
+    saveCredentials?: boolean;
+  }) {
+    const connectionsStore = await this.getConnectionsStore();
+    const credentialsStore = await this.getCredentialsStore();
+
+    const connectionData = {
+      id: connection.id,
+      name: connection.name,
+      host: connection.host,
+      port: connection.port,
+      username: connection.username,
+      keyPath: connection.keyPath,
+      type: connection.type,
+      isConnected: false,
+      saveCredentials: connection.saveCredentials,
+    };
+
+    await connectionsStore.set(connection.id, connectionData);
+
+    if (connection.saveCredentials && connection.password) {
+      await credentialsStore.set(connection.id, {
+        password: connection.password,
+      });
+    } else {
+      await credentialsStore.delete(connection.id);
+    }
+
+    await connectionsStore.save();
+    await credentialsStore.save();
+  }
+
+  async getConnection(connectionId: string) {
+    const connectionsStore = await this.getConnectionsStore();
+    const credentialsStore = await this.getCredentialsStore();
+
+    const connection = await connectionsStore.get(connectionId);
+    if (!connection) return null;
+
+    const credentials = await credentialsStore.get(connectionId);
+
+    return {
+      ...connection,
+      password: credentials?.password,
+    };
+  }
+
+  async getAllConnections() {
+    const connectionsStore = await this.getConnectionsStore();
+    const credentialsStore = await this.getCredentialsStore();
+
+    const connectionIds: string[] = await connectionsStore.keys();
+    const connections = [];
+
+    for (const id of connectionIds) {
+      const connection = await connectionsStore.get(id);
+      if (connection) {
+        const credentials = await credentialsStore.get(id);
+        connections.push({
+          ...connection,
+          password: credentials?.password,
+        });
+      }
+    }
+
+    return connections;
+  }
+
+  async deleteConnection(connectionId: string) {
+    const connectionsStore = await this.getConnectionsStore();
+    const credentialsStore = await this.getCredentialsStore();
+
+    await connectionsStore.delete(connectionId);
+    await credentialsStore.delete(connectionId);
+
+    await connectionsStore.save();
+    await credentialsStore.save();
+  }
+
+  async updateConnectionStatus(connectionId: string, isConnected: boolean, lastConnected?: string) {
+    const connectionsStore = await this.getConnectionsStore();
+    const connection = await connectionsStore.get(connectionId);
+
+    if (connection) {
+      const updatedConnection = {
+        ...connection,
+        isConnected,
+        lastConnected: lastConnected || connection.lastConnected,
+      };
+
+      await connectionsStore.set(connectionId, updatedConnection);
+      await connectionsStore.save();
+    }
+  }
+
+  async migrateFromLocalStorage() {
+    try {
+      const stored = localStorage.getItem("athas-remote-connections");
+      if (stored) {
+        const connections = JSON.parse(stored);
+
+        for (const conn of connections) {
+          await this.saveConnection({
+            ...conn,
+            saveCredentials: !!conn.password,
+          });
+        }
+
+        localStorage.removeItem("athas-remote-connections");
+        console.log("Successfully migrated connections from localStorage to Tauri Store");
+      }
+    } catch (error) {
+      console.error("Error migrating from localStorage:", error);
+    }
+  }
+}
+
+export const connectionStore = new ConnectionStore();


### PR DESCRIPTION
## Changes
- Prevent duplicate remote windows: focus existing window if already open.
- Use overlay title bar with hidden title and transparency; request user attention on create.
- Added capability `core:window:allow-destroy` to permit programmatic window destroy.
- `ssh_disconnect` now receives AppHandle and also closes the associated remote window.
- Added `ssh_disconnect_only` to disconnect without closing the window (used on window close flow).
- Wired new command in main.rs.
- Detect remote windows via URL param `?remote=<id>`; set remote window state.
- Listen for `remote-connection-info` events to populate sidebar store (name/id/isRemoteWindow).
- Intercept window close for remote windows: prevent default, call `ssh_disconnect_only`, emit `remote-connection-disconnected`, then destroy the window.
- Project name loading is async; for remote windows shows `Remote: <connection name>`.
- More robust remote window lifecycle: no duplicate windows, proper cleanup on close, and OS-level UX improvements.
- Clearer remote context in UI, with dedicated remote window behavior and optional credential saving.
- Hide Remote Connections button inside remote connection windows (`sidebar-pane-selector.tsx`)

![remote-connection-bugs](https://github.com/user-attachments/assets/e823801b-88d4-48d1-8302-25c601db6b59)