### PR TITLE
Use dynamic proxy port, instead of hardcoded

### DIFF
--- a/src-tauri/src/claude_bridge.rs
+++ b/src-tauri/src/claude_bridge.rs
@@ -46,8 +46,8 @@ impl ClaudeCodeBridge {
 
       log::info!("Starting interceptor as embedded service...");
 
-      // Start the interceptor proxy server on an ephemeral port and get the actual port
-      let (rx, ws_state, server_handle, proxy_port) = start_proxy_server_with_ws(None).await?;
+      // Start the interceptor proxy server on an ephemeral port and get the assigned port
+      let (rx, ws_state, server_handle, assigned_port) = start_proxy_server_with_ws(None).await?;
 
       // Create channels for message distribution
       let (broadcast_tx, mut broadcast_rx) = mpsc::unbounded_channel::<InterceptorMessage>();
@@ -75,9 +75,9 @@ impl ClaudeCodeBridge {
       self.interceptor_handle = Some(message_handler);
       self.server_handle = Some(server_handle);
       self.ws_connected = true;
-      self.proxy_port = Some(proxy_port);
+      self.proxy_port = Some(assigned_port);
 
-      log::info!("Interceptor started successfully on port {}", proxy_port);
+      log::info!("Interceptor started successfully on port {}", assigned_port);
       Ok(())
    }
 


### PR DESCRIPTION
# Pull Request

What I changed:
- `athas/src-tauri/packages/interceptor/src/server.rs`
  - Updated `start_proxy_server_with_ws` to accept an optional port (`Option<u16>`). If `None`, it binds to port 0 to let the OS pick a free port, then returns the actual port.
  - Logs now show the real port.
  - Function signature now returns the port: `(rx, ws_state, server_handle, actual_port)`.

- `athas/src-tauri/src/claude_bridge.rs`
  - Calls `start_proxy_server_with_ws(None)` so we use a free port.
  - Stores the selected `proxy_port` in the bridge state.
  - Sets the `claude` child process env var `ANTHROPIC_BASE_URL` to `http://localhost:{proxy_port}`.
  - Removed the hardcoded 3456 and duplicates.


