### PR TITLE
Clean up setup scripts & docs for next release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "@commitlint/cli": "^19.8.1",
         "@tailwindcss/vite": "^4.1.11",
         "@tauri-apps/cli": "^2",
+        "@types/bun": "^1.2.21",
         "@types/node": "^24.1.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -452,6 +453,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.7", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng=="],
 
+    "@types/bun": ["@types/bun@1.2.21", "", { "dependencies": { "bun-types": "1.2.21" } }, "sha512-NiDnvEqmbfQ6dmZ3EeUO577s4P5bf4HCTXtI6trMc6f6RzirY5IrF3aIookuSpyslFzrnvv2lmEWv5HyC1X79A=="],
+
     "@types/conventional-commits-parser": ["@types/conventional-commits-parser@5.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -513,6 +516,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.25.1", "", { "dependencies": { "caniuse-lite": "^1.0.30001726", "electron-to-chromium": "^1.5.173", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw=="],
+
+    "bun-types": ["bun-types@1.2.21", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-sa2Tj77Ijc/NTLS0/Odjq/qngmEPZfbfnOERi0KRUYhT9R8M4VBioWVmMWE5GrYbKMc+5lVybXygLdibHaqVqw=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 

--- a/docs/develop/linux.md
+++ b/docs/develop/linux.md
@@ -15,6 +15,15 @@ bun setup
 1. **Install Bun**: Visit [bun.sh](https://bun.sh) for installation instructions
 2. **Install Rust**: Visit [rustup.rs](https://rustup.rs) for installation instructions
 
+**Additional Packages**
+
+When installing `git2` and `ssh2` crates using `vendored-openssl` features, there are additional packages you may need to prevent installation failure
+
+This one's for Fedora, but the packages should be the same for other distros
+```sh
+sudo dnf install openssl-devel pkgconf perl-FindBin perl-IPC-Cmd perl
+```
+
 ### Setup
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "clean": "concurrently --names \"node,rust\" --prefix-colors \"cyan,yellow\" \"rimraf dist build node_modules bun.lockb && bun install\" \"cargo clean && cargo build\"",
     "prepare": "simple-git-hooks",
     "commitlint": "commitlint",
-    "setup": "chmod +x scripts/linux/setup.sh && ./scripts/linux/setup.sh",
-    "setup:linux": "chmod +x scripts/linux/setup.sh && ./scripts/linux/setup.sh",
-    "setup-win": "powershell -ExecutionPolicy Bypass -File ./scripts/windows/setup.ps1",
+    "setup": "bun setup.ts",
     "dev": "bun run tauri dev"
   },
   "dependencies": {
@@ -69,6 +67,7 @@
     "@commitlint/cli": "^19.8.1",
     "@tailwindcss/vite": "^4.1.11",
     "@tauri-apps/cli": "^2",
+    "@types/bun": "^1.2.21",
     "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/scripts/linux/setup.sh
+++ b/scripts/linux/setup.sh
@@ -103,34 +103,6 @@ install_bun() {
     fi
 }
 
-install_node() {
-    if command_exists node; then
-        NODE_VERSION=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
-        if [ "$NODE_VERSION" -ge 18 ]; then
-            print_success "Node.js is already installed ($(node --version))"
-            return
-        fi
-    fi
-
-    print_status "Installing Node.js LTS..."
-    case $DISTRO in
-        "ubuntu")
-            curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
-            sudo apt-get install -y nodejs
-            ;;
-        "fedora")
-            sudo dnf install -y nodejs npm
-            ;;
-        "arch")
-            sudo pacman -S --needed --noconfirm nodejs npm
-            ;;
-        "opensuse")
-            sudo zypper install -y nodejs18 npm18
-            ;;
-    esac
-    print_success "Node.js installation completed"
-}
-
 install_project_deps() {
     print_status "Installing project dependencies..."
 
@@ -139,9 +111,6 @@ install_project_deps() {
     if command_exists bun; then
         bun install
         print_success "Dependencies installed with Bun"
-    elif command_exists npm; then
-        npm install
-        print_success "Dependencies installed with npm"
     else
         print_warning "Package manager not found, but continuing..."
     fi
@@ -181,7 +150,6 @@ main() {
     install_rust
     install_tauri_cli
     install_bun
-    install_node
     install_project_deps
     verify_basic
 

--- a/scripts/linux/setup.sh
+++ b/scripts/linux/setup.sh
@@ -40,15 +40,23 @@ install_system_deps() {
         "ubuntu")
             sudo apt update
             sudo apt install -y build-essential curl wget file libssl-dev libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libayatana-appindicator3-dev librsvg2-dev pkg-config
+            # Deps for git2 and ssh2
+            sudo apt install -y openssl-devel pkgconf perl-FindBin perl-IPC-Cmd perl
             ;;
         "fedora")
             sudo dnf install -y gcc gcc-c++ make curl wget file openssl-devel gtk3-devel webkit2gtk4.1-devel libsoup3-devel libayatana-appindicator-gtk3-devel librsvg2-devel pkgconf-pkg-config
+            # Deps for git2 and ssh2
+            sudo dnf install -y openssl-devel pkgconf perl-FindBin perl-IPC-Cmd perl
             ;;
         "arch")
             sudo pacman -S --needed --noconfirm base-devel curl wget file openssl gtk3 webkit2gtk-4.1 libsoup3 libayatana-appindicator librsvg pkgconf
+            # Deps for git2 and ssh2
+            sudo pacman -S --needed --noconfirm openssl-devel pkgconf perl-FindBin perl-IPC-Cmd perl
             ;;
         "opensuse")
             sudo zypper install -y gcc gcc-c++ make curl wget file libopenssl-devel gtk3-devel webkit2gtk3-devel libsoup3-devel libayatana-appindicator3-devel librsvg-devel pkg-config
+            # Deps for git2 and ssh2
+            sudo zypper install -y openssl-devel pkgconf perl-FindBin perl-IPC-Cmd perl
             ;;
         *)
             print_error "Unsupported Linux distribution: $DISTRO"

--- a/setup.ts
+++ b/setup.ts
@@ -1,0 +1,14 @@
+import os from "node:os";
+import { $ } from "bun";
+
+const WINDOWS = "win32";
+const MAC = "darwin";
+const LINUX = "linux";
+
+const platform = os.platform();
+
+if (platform === WINDOWS) {
+  await $`powershell -ExecutionPolicy Bypass -File ./scripts/windows/setup.ps1`;
+} else if (platform === MAC || platform === LINUX) {
+  await $`chmod +x scripts/linux/setup.sh && ./scripts/linux/setup.sh`;
+}


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- Created a unified `setup.ts` script that detects the user's OS and runs the OS-specific setup scripts
- Added docs for additional packages needed to make `git2` and `ssh2` work. These are also automated in the setup script
- Removed nodejs install step - Bun is a faster replacement for the runtime AND package manager to replace npm


