### PR TITLE
Disable WebKitGTK DMABUF impl for GPU rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "simple-git-hooks",
     "commitlint": "commitlint",
     "setup": "bun setup.ts",
-    "dev": "WEBKIT_DISABLE_DMABUF_RENDERER=1 bun tauri dev"
+    "dev": "WEBKIT_DISABLE_DMABUF_RENDERER=1 tauri dev"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "simple-git-hooks",
     "commitlint": "commitlint",
     "setup": "bun setup.ts",
-    "dev": "bun run tauri dev"
+    "dev": "WEBKIT_DISABLE_DMABUF_RENDERER=1 bun tauri dev"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",


### PR DESCRIPTION
This is only for the `bun dev` command. Devs can run `bun tauri` with their own flags if this doesn't work or if they choose to use software rendering.

This has been a known issue since WebKitGTK 2.41.1, perhaps due to regression of the new DMABUF implementation. Not all distros have this fixed by default (besides Ubuntu), so this flag is needed.

This has only been tested with NVIDIA's proprietary drivers, so proceed with caution with open-source drivers and other GPUs.

---

Environment tested in, excerpt from `tauri info`:
```
[✔] Environment
    - OS: Fedora 42.0.0 x86_64 (X64) (gnome on wayland)
    ✔ webkit2gtk-4.1: 2.48.5
```

---

Related:
- #274