### PR TITLE
Improve click outside behavior for dropdown component

### DIFF
--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -45,7 +45,13 @@ const Dropdown = ({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  useOnClickOutside(dropdownRef as RefObject<HTMLElement>, () => setIsOpen(false));
+  useOnClickOutside(dropdownRef as RefObject<HTMLElement>, (event) => {
+    const target = event.target as HTMLElement;
+    if (target && buttonRef.current?.contains(target)) {
+      return;
+    }
+    setIsOpen(false);
+  });
 
   // Update dropdown position when opened
   useEffect(() => {


### PR DESCRIPTION
Expected:

click trigger -> dropdown appeared -> click trigger -> dropdown disappear

Now:

click trigger -> dropdown appeared -> click trigger -> dropdown disappear and then appear again


<table>
<tr>
 <td>
 Before
 <td>
 After
<tr>
 <td>

![CleanShot 2025-10-20 at 10 11 30](https://github.com/user-attachments/assets/4096c49f-6a8c-46b0-86d8-4b8728601289)

 <td>

![CleanShot 2025-10-20 at 10 11 10](https://github.com/user-attachments/assets/411fa401-1a6a-46aa-bf39-acf5eb91d39d)

</table>