### PR TITLE
Improve ux in switching project

### DIFF
--- a/src/components/layout/main-sidebar.tsx
+++ b/src/components/layout/main-sidebar.tsx
@@ -94,7 +94,7 @@ export const MainSidebar = memo(() => {
     };
 
     loadProjectName();
-  }, [getProjectName, isRemoteWindow]);
+  }, [isFileTreeLoading, getProjectName, isRemoteWindow]);
 
   // Register search view ref with store when it becomes available
   useEffect(() => {

--- a/src/file-system/controllers/store.ts
+++ b/src/file-system/controllers/store.ts
@@ -58,11 +58,11 @@ export const useFileSystemStore = createSelectors(
 
       // Actions
       handleOpenFolder: async () => {
+        const selected = await openFolder();
+
         set((state) => {
           state.isFileTreeLoading = true;
         });
-
-        const selected = await openFolder();
 
         if (!selected) {
           set((state) => {


### PR DESCRIPTION
1. Project name doesn't update when switching projects.

2. When we open folder the file tree's state will be loading immediately, but actually we only should update it to loading after we selected the folder.
