### PR TITLE
Update Windows development documentation

### DIFF
--- a/docs/develop/windows.md
+++ b/docs/develop/windows.md
@@ -5,7 +5,7 @@
 Use the automated setup script:
 
 ```bash
-bun setup-win
+bun setup
 ```
 
 ## Manual Setup
@@ -14,6 +14,7 @@ bun setup-win
 
 1. **Install Bun**: Visit [bun.sh](https://bun.sh) for installation instructions
 2. **Install Rust**: Visit [rustup.rs](https://rustup.rs) for installation instructions
+3. **Install Perl**: Visit [perl.org](https://www.perl.org) for installation instructions
 
 ### Setup
 


### PR DESCRIPTION
Add instructions for installing Perl and fix the setup command.

## Description

Replaced `bun setup-win` with `bun setup` since `setup-win` no longer exists

Added `Perl` installation step to the manual setup section as it is required

