### PR TITLE
Add GPT-5 family models to providers.ts

### DIFF
--- a/src/features/ai/types/providers.ts
+++ b/src/features/ai/types/providers.ts
@@ -34,6 +34,26 @@ export const AI_PROVIDERS: ModelProvider[] = [
     models: [
       // Latest flagship models
       {
+        id: "gpt-5-pro",
+        name: "GPT-5 Pro",
+        maxTokens: 128000,
+      },
+      {
+        id: "gpt-5",
+        name: "GPT-5",
+        maxTokens: 1048576,
+      },
+      {
+        id: "gpt-5-mini",
+        name: "GPT-5 Mini",
+        maxTokens: 1048576,
+      },
+      {
+        id: "gpt-5-nano",
+        name: "GPT-5 Nano",
+        maxTokens: 1048576,
+      },
+      {
         id: "o3",
         name: "o3",
         maxTokens: 200000,


### PR DESCRIPTION
Added new GPT-5 models with respective IDs and maxTokens.

# Pull Request

The new GPT 5 family of models has been out for a while, so I've added them.

## Description

the following models were added:

```ts
{
  id: "gpt-5-pro",
  name: "GPT-5 Pro",
  maxTokens: 128000,
},
{
  id: "gpt-5",
  name: "GPT-5",
  maxTokens: 1048576,
},
{
  id: "gpt-5-mini",
  name: "GPT-5 Mini",
  maxTokens: 1048576,
},
{
  id: "gpt-5-nano",
  name: "GPT-5 Nano",
  maxTokens: 1048576,
}
```