### PR TITLE
Remove unused import path::Path on cli.rs

### DIFF
--- a/src-tauri/src/commands/cli.rs
+++ b/src-tauri/src/commands/cli.rs
@@ -1,6 +1,8 @@
+use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::{fs, path::Path};
+#[cfg(unix)]
+use std::path::Path;
 use tauri::command;
 
 // Platform-specific CLI paths

--- a/src-tauri/src/lsp/client.rs
+++ b/src-tauri/src/lsp/client.rs
@@ -24,7 +24,6 @@ pub struct LspClient {
    stdin_tx: Sender<String>,
    pending_requests: PendingRequests,
    capabilities: Arc<Mutex<Option<ServerCapabilities>>>,
-   app_handle: Option<AppHandle>,
 }
 
 impl LspClient {
@@ -147,7 +146,6 @@ impl LspClient {
          stdin_tx,
          pending_requests,
          capabilities: Arc::new(Mutex::new(None)),
-         app_handle,
       };
 
       // Don't initialize here - we'll do it separately to avoid runtime issues


### PR DESCRIPTION

# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

- Made path::Path import conditional with #[cfg(unix)] since it's only used in Unix-specific code blocks
- Removed the unused app_handle field from the LspClient struct. The field was being stored but never actually read from the struct (it was only used via the function parameter before being stored)

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes # Fixes #400 


