### PR TITLE
Making sure you can exit out of a terminal

### DIFF
--- a/src/features/terminal/components/terminal-container.tsx
+++ b/src/features/terminal/components/terminal-container.tsx
@@ -26,7 +26,7 @@ const TerminalContainer = ({
     terminals,
     activeTerminalId,
     createTerminal,
-    closeTerminal,
+    closeTerminal: originalCloseTerminal,
     setActiveTerminal,
     updateTerminalName,
     updateTerminalDirectory,
@@ -37,6 +37,15 @@ const TerminalContainer = ({
     switchToPrevTerminal,
     setTerminalSplitMode,
   } = useTerminalTabs();
+
+  // Wrapper to add logging and ensure terminal closes properly
+  const closeTerminal = useCallback(
+    (terminalId: string) => {
+      console.log("closeTerminal called for terminal:", terminalId);
+      originalCloseTerminal(terminalId);
+    },
+    [originalCloseTerminal],
+  );
 
   const zoomLevel = useZoomStore.use.terminalZoomLevel();
 
@@ -429,6 +438,7 @@ const TerminalContainer = ({
                       onDirectoryChange={handleDirectoryChange}
                       onActivity={handleActivity}
                       onRegisterRef={registerTerminalRef}
+                      onTerminalExit={closeTerminal}
                     />
                   </div>
                   {terminal.splitMode && terminal.splitWithId && (
@@ -444,6 +454,7 @@ const TerminalContainer = ({
                         onDirectoryChange={handleDirectoryChange}
                         onActivity={handleActivity}
                         onRegisterRef={registerTerminalRef}
+                        onTerminalExit={closeTerminal}
                       />
                     </div>
                   )}

--- a/src/features/terminal/components/terminal-session.tsx
+++ b/src/features/terminal/components/terminal-session.tsx
@@ -9,6 +9,7 @@ interface TerminalSessionProps {
   onDirectoryChange?: (terminalId: string, directory: string) => void;
   onActivity?: (terminalId: string) => void;
   onRegisterRef?: (terminalId: string, ref: { focus: () => void } | null) => void;
+  onTerminalExit?: (terminalId: string) => void;
 }
 
 const TerminalSession = ({
@@ -16,6 +17,7 @@ const TerminalSession = ({
   isActive,
   onActivity,
   onRegisterRef,
+  onTerminalExit,
 }: TerminalSessionProps) => {
   const terminalRef = useRef<any>(null);
   const xtermInstanceRef = useRef<any>(null);
@@ -61,6 +63,7 @@ const TerminalSession = ({
             xtermInstanceRef.current = ref;
             terminalRef.current = ref;
           }}
+          onTerminalExit={onTerminalExit}
         />
       </TerminalErrorBoundary>
     </div>

--- a/src/features/terminal/components/terminal.tsx
+++ b/src/features/terminal/components/terminal.tsx
@@ -25,6 +25,7 @@ interface XtermTerminalProps {
   isActive: boolean;
   onReady?: () => void;
   onTerminalRef?: (ref: any) => void;
+  onTerminalExit?: (sessionId: string) => void;
 }
 
 interface TerminalTheme {
@@ -57,6 +58,7 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
   isActive,
   onReady,
   onTerminalRef,
+  onTerminalExit,
 }) => {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
@@ -67,6 +69,13 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const isInitializingRef = useRef(false);
   const currentConnectionIdRef = useRef<string | null>(null);
+  const onTerminalExitRef = useRef(onTerminalExit);
+  const currentInputLineRef = useRef<string>("");
+
+  // Keep ref in sync with prop
+  useEffect(() => {
+    onTerminalExitRef.current = onTerminalExit;
+  }, [onTerminalExit]);
 
   const { updateSession, getSession } = useTerminalStore();
   const { currentTheme } = useThemeStore();
@@ -277,8 +286,56 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
 
         // Handle terminal input
         terminal.onData((data) => {
-          // Use the ref to always have the current connection ID
           const currentId = currentConnectionIdRef.current || connectionId;
+
+          // Track input to detect "exit" command
+          // Check if this data contains a newline/carriage return (command submitted)
+          const hasNewline = data.includes("\n") || data.includes("\r");
+
+          if (hasNewline) {
+            // Command is being submitted - check if it's "exit"
+            currentInputLineRef.current += data;
+            const trimmedLine = currentInputLineRef.current.trim();
+
+            // Check if the command is exactly "exit" (case-insensitive, allowing whitespace)
+            if (/^\s*exit\s*$/i.test(trimmedLine)) {
+              // Reset input tracking
+              currentInputLineRef.current = "";
+
+              // Send the exit command to the terminal first
+              invoke("terminal_write", { id: currentId, data }).catch((e) => {
+                console.error("Failed to write to terminal:", e);
+              });
+
+              // Wait a moment for the shell to process exit, then close the terminal
+              setTimeout(() => {
+                const callback = onTerminalExitRef.current;
+                if (callback) {
+                  console.log("Detected exit command, closing terminal session:", sessionId);
+                  // Close backend connection
+                  invoke("close_xterm_terminal", { id: currentId }).catch((e) => {
+                    console.error("Failed to close backend terminal connection:", e);
+                  });
+                  // Close the terminal tab
+                  callback(sessionId);
+                }
+              }, 100);
+              return;
+            } else {
+              // Not an exit command, reset tracking
+              currentInputLineRef.current = "";
+            }
+          } else {
+            // No newline yet, accumulate input
+            currentInputLineRef.current += data;
+
+            // Prevent unbounded growth
+            if (currentInputLineRef.current.length > 1000) {
+              currentInputLineRef.current = currentInputLineRef.current.slice(-100);
+            }
+          }
+
+          // Send data to terminal
           invoke("terminal_write", { id: currentId, data }).catch((e) => {
             console.error("Failed to write to terminal:", e);
           });
@@ -454,9 +511,28 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
       }
     });
 
-    const unlistenClosed = listen(closedEventName, () => {
-      console.log("Terminal closed:", connectionId);
-      if (xtermRef.current) {
+    const unlistenClosed = listen(closedEventName, async () => {
+      console.log(
+        "Terminal closed event received for connection:",
+        connectionId,
+        "session:",
+        sessionId,
+      );
+
+      // Close the backend connection
+      try {
+        await invoke("close_xterm_terminal", { id: connectionId });
+        console.log("Backend terminal connection closed for:", connectionId);
+      } catch (e) {
+        console.error("Failed to close backend terminal connection:", e);
+      }
+
+      // Call the exit callback to close the terminal tab
+      const callback = onTerminalExitRef.current;
+      if (callback) {
+        console.log("Calling onTerminalExit callback for session:", sessionId);
+        callback(sessionId);
+      } else if (xtermRef.current) {
         xtermRef.current.writeln("\r\n\x1b[33mTerminal session closed\x1b[0m");
       }
     });


### PR DESCRIPTION
This PR implements automatic terminal closure when the user types the "exit" command, matching standard terminal behavior.

## Changes

- Added `onTerminalExit` callback prop to `XtermTerminal` component
- Implemented frontend detection of "exit" command in terminal input
- When "exit" is detected, the terminal automatically closes the backend connection and removes the terminal tab
- Added proper cleanup and logging for debugging

## Behavior

When a user types "exit" and presses Enter in a terminal:
1. The command is sent to the shell (so it executes normally)
2. The frontend detects the exit command
3. The backend connection is closed
4. The terminal tab is automatically removed
5. If other terminals exist, focus switches to another one

This works reliably even if the backend PTY doesn't emit the `pty-closed` event, as we detect the exit command directly in the frontend.