### PR TITLE
Fix: replace GitHub Copilot API key input with Coming Soon notice

### DIFF
--- a/src/features/ai/components/github-copilot-settings.tsx
+++ b/src/features/ai/components/github-copilot-settings.tsx
@@ -1,9 +1,6 @@
-import { AlertCircle, CheckCircle, Key, Zap } from "lucide-react";
-import { useEffect, useState } from "react";
+import { AlertCircle, Zap } from "lucide-react";
 import { useUIState } from "@/stores/ui-state-store";
 import Button from "@/ui/button";
-import { removeGitHubToken, storeGitHubToken } from "@/utils/ai-completion";
-import { cn } from "@/utils/cn";
 
 const GitHubCopilotSettings = () => {
   // Get data from stores
@@ -11,112 +8,6 @@ const GitHubCopilotSettings = () => {
 
   const isVisible = isGitHubCopilotSettingsVisible;
   const onClose = () => setIsGitHubCopilotSettingsVisible(false);
-  const [apiKey, setApiKey] = useState("");
-  const [isValidating, setIsValidating] = useState(false);
-  const [validationStatus, setValidationStatus] = useState<"idle" | "valid" | "invalid">("idle");
-  const [errorMessage, setErrorMessage] = useState("");
-  const [hasExistingKey, setHasExistingKey] = useState(false);
-
-  // Load existing key on mount
-  useEffect(() => {
-    if (isVisible) {
-      loadExistingKey();
-    }
-  }, [isVisible]);
-
-  const loadExistingKey = async () => {
-    try {
-      // Check if key exists without exposing it
-      const { invoke } = await import("@tauri-apps/api/core");
-      const key = (await invoke("get_github_token")) as string | null;
-      if (key) {
-        setHasExistingKey(true);
-        setApiKey("••••••••••••••••••••"); // Mask existing key
-      } else {
-        setHasExistingKey(false);
-        setApiKey("");
-      }
-    } catch (error) {
-      console.error("Error loading API key:", error);
-      setHasExistingKey(false);
-    }
-  };
-
-  const validateOpenAIKey = async (key: string): Promise<boolean> => {
-    try {
-      // Test the key by making a simple API call
-      const response = await fetch("https://api.openai.com/v1/models", {
-        headers: {
-          Authorization: `Bearer ${key}`,
-        },
-      });
-
-      if (response.ok) {
-        return true;
-      } else {
-        throw new Error(`OpenAI API error: ${response.status}`);
-      }
-    } catch (_error) {
-      console.error("API key validation error:", _error);
-      return false;
-    }
-  };
-
-  const handleSaveKey = async () => {
-    // If using existing key, just close
-    if (hasExistingKey && apiKey.startsWith("•")) {
-      onClose();
-      return;
-    }
-
-    if (!apiKey.trim()) {
-      setErrorMessage("Please enter an OpenAI API key");
-      return;
-    }
-
-    setIsValidating(true);
-    setValidationStatus("idle");
-    setErrorMessage("");
-
-    try {
-      const isValid = await validateOpenAIKey(apiKey);
-
-      if (isValid) {
-        await storeGitHubToken(apiKey);
-        setValidationStatus("valid");
-        setTimeout(() => {
-          onClose();
-        }, 1000);
-      } else {
-        setValidationStatus("invalid");
-        setErrorMessage("Invalid GitHub token. Please check your token and try again.");
-      }
-    } catch {
-      setValidationStatus("invalid");
-      setErrorMessage("Failed to validate token. Please try again.");
-    } finally {
-      setIsValidating(false);
-    }
-  };
-
-  const handleRemoveKey = async () => {
-    try {
-      await removeGitHubToken();
-      setHasExistingKey(false);
-      setApiKey("");
-      setValidationStatus("idle");
-      setErrorMessage("");
-    } catch {
-      setErrorMessage("Failed to remove token");
-    }
-  };
-
-  const handleKeyChange = (value: string) => {
-    setApiKey(value);
-    setValidationStatus("idle");
-    setErrorMessage("");
-    setHasExistingKey(false); // User is entering new token
-  };
 
   if (!isVisible) {
     return null;
@@ -131,7 +22,7 @@ const GitHubCopilotSettings = () => {
         {/* Header */}
         <div className="flex items-center gap-3 border-border border-b px-4 py-3">
           <Zap size={16} className="text-text" />
-          <h2 className="ui-font font-medium text-sm text-text">AI Code Completion Setup</h2>
+          <h2 className="ui-font font-medium text-sm text-text">GitHub Copilot Integration</h2>
           <div className="flex-1" />
           <button onClick={onClose} className="text-text-lighter transition-colors hover:text-text">
             ×
@@ -141,94 +32,39 @@ const GitHubCopilotSettings = () => {
         {/* Content */}
         <div className="space-y-4 p-4">
           <div className="text-text-lighter text-xs leading-relaxed">
-            Connect to OpenAI's API for intelligent code completions powered by GPT-3.5.
+            GitHub Copilot integration uses official GitHub authentication through the code Editor.
           </div>
 
-          {/* API Key Input */}
-          <div className="space-y-2">
-            <label
-              htmlFor="openai-api-key"
-              className="flex items-center gap-2 font-medium text-text text-xs"
-            >
-              <Key size={12} />
-              OpenAI API Key
-            </label>
-
-            <input
-              id="openai-api-key"
-              type="password"
-              value={apiKey}
-              onChange={(e) => handleKeyChange(e.target.value)}
-              placeholder="sk-xxxxxxxxxxxxxxxxxxxx"
-              className={cn(
-                "w-full rounded border border-border bg-secondary-bg",
-                "ui-font px-3 py-2 text-text text-xs",
-                "focus:border-blue-500 focus:outline-none",
-              )}
-              disabled={isValidating}
-            />
-
-            {/* Validation Status */}
-            {validationStatus === "valid" && (
-              <div className="flex items-center gap-2 text-green-500 text-xs">
-                <CheckCircle size={12} />
-                API key validated successfully!
-              </div>
-            )}
-
-            {validationStatus === "invalid" && (
-              <div className="flex items-center gap-2 text-red-500 text-xs">
-                <AlertCircle size={12} />
-                {errorMessage}
-              </div>
-            )}
+          {/* Coming Soon Notice */}
+          <div className="space-y-3 rounded border border-border bg-secondary-bg p-4">
+            <div className="flex items-center gap-2 text-text text-sm font-medium">
+              <AlertCircle size={14} className="text-blue-400" />
+              <span>Coming Soon</span>
+            </div>
+            <div className="text-text-lighter text-xs leading-relaxed">
+              GitHub Copilot integration is currently in development. GitHub Copilot does not
+              support API key authentication. It requires OAuth-based authentication through
+              official GitHub channels.
+            </div>
           </div>
 
-          {/* Instructions */}
+          {/* Information */}
           <div className="space-y-2 rounded border border-border bg-secondary-bg p-3">
             <div className="mb-2 font-medium text-text text-xs">
-              How to get your OpenAI API key:
+              How GitHub Copilot authentication works:
             </div>
-            <ol className="list-inside list-decimal space-y-1 text-text-lighter text-xs">
-              <li>
-                Go to{" "}
-                <a
-                  href="https://platform.openai.com/api-keys"
-                  className="text-blue-400 hover:text-blue-300"
-                >
-                  OpenAI API Keys
-                </a>
-              </li>
-              <li>Click "Create new secret key"</li>
-              <li>Copy the generated key and paste it above</li>
-              <li>Note: You'll need credits in your OpenAI account</li>
-            </ol>
+            <ul className="list-inside list-disc space-y-1 text-text-lighter text-xs">
+              <li>Requires a GitHub Copilot subscription</li>
+              <li>Uses OAuth authentication with GitHub</li>
+              <li>Integrates through official IDE extensions</li>
+              <li>Does not support standalone API keys</li>
+            </ul>
           </div>
 
           {/* Actions */}
           <div className="flex gap-2 pt-2">
-            <Button
-              onClick={handleSaveKey}
-              disabled={!apiKey.trim() || isValidating}
-              className="flex-1"
-            >
-              {isValidating
-                ? "Validating..."
-                : hasExistingKey && apiKey.startsWith("•")
-                  ? "Use Existing"
-                  : "Save & Connect"}
-            </Button>
-            {hasExistingKey && (
-              <Button
-                onClick={handleRemoveKey}
-                variant="ghost"
-                className="px-4 text-red-500 hover:bg-red-500/10"
-              >
-                Remove
-              </Button>
-            )}
-            <Button onClick={onClose} variant="ghost" className="px-4">
-              Cancel
+            <Button onClick={onClose} variant="default" className="flex-1">
+              Got it
             </Button>
           </div>
         </div>

--- a/src/features/ai/types/providers.ts
+++ b/src/features/ai/types/providers.ts
@@ -3,6 +3,7 @@ interface ModelProvider {
   name: string;
   apiUrl: string;
   requiresApiKey: boolean;
+  requiresAuth?: boolean;
   models: Model[];
 }
 
@@ -289,7 +290,8 @@ export const AI_PROVIDERS: ModelProvider[] = [
     id: "copilot",
     name: "GitHub Copilot",
     apiUrl: "https://api.githubcopilot.com/chat/completions",
-    requiresApiKey: true,
+    requiresApiKey: false,
+    requiresAuth: true,
     models: [
       {
         id: "gpt-4.1",

--- a/src/features/settings/components/tabs/ai-settings.tsx
+++ b/src/features/settings/components/tabs/ai-settings.tsx
@@ -252,6 +252,11 @@ export const AISettings = () => {
   // Get all providers that require API keys
   const providersNeedingKeys = getAvailableProviders().filter((p) => p.requiresApiKey);
 
+  // Get all providers that require authentication (but not API keys)
+  const providersNeedingAuth = getAvailableProviders().filter(
+    (p) => p.requiresAuth && !p.requiresApiKey,
+  );
+
   return (
     <div className="space-y-4">
       <Section title="Provider & Model">
@@ -277,13 +282,31 @@ export const AISettings = () => {
         </SettingRow>
       </Section>
 
-      <Section title="API Keys">
-        {providersNeedingKeys.map((provider) => (
-          <SettingRow key={provider.id} label={provider.name}>
-            {renderApiKeyInput(provider.id, provider.name)}
-          </SettingRow>
-        ))}
-      </Section>
+      {providersNeedingKeys.length > 0 && (
+        <Section title="API Keys">
+          {providersNeedingKeys.map((provider) => (
+            <SettingRow key={provider.id} label={provider.name}>
+              {renderApiKeyInput(provider.id, provider.name)}
+            </SettingRow>
+          ))}
+        </Section>
+      )}
+
+      {providersNeedingAuth.length > 0 && (
+        <Section title="Authentication">
+          {providersNeedingAuth.map((provider) => (
+            <SettingRow
+              key={provider.id}
+              label={provider.name}
+              description="Requires OAuth authentication"
+            >
+              <div className="flex items-center gap-2 rounded border border-border bg-secondary-bg px-3 py-1.5">
+                <span className="text-text-lighter text-xs">Coming Soon</span>
+              </div>
+            </SettingRow>
+          ))}
+        </Section>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Problem
When navigating to Settings > AI, GitHub Copilot was listed under API Keys with an input field requesting an API key. However, GitHub Copilot does not support API key authentication; it only works through official OAuth-based integrations.

This created confusion for users who might attempt to connect Copilot via an API key, which is not technically possible.

## Description
- Added `requiresAuth` field to the `ModelProvider` interface to distinguish providers requiring OAuth authentication
- Set GitHub Copilot to `requiresApiKey: false` and `requiresAuth: true`
- Created a separate "Authentication" section in AI settings for OAuth-based providers
- Display "Coming Soon" badge with "Requires OAuth authentication" description
- Updated GitHub Copilot settings dialog to show proper information about OAuth requirements

## Screenshots/Videos

<img width="1919" height="1017" alt="image" src="https://github.com/user-attachments/assets/f840d475-d429-48c8-9ba0-43a9ddf9497f" />



## Related Issues

Fixes, Closes #407 



