### PR TITLE
Add session time tracking with enable/disable toggle

### DIFF
--- a/src/features/layout/components/footer/editor-footer.tsx
+++ b/src/features/layout/components/footer/editor-footer.tsx
@@ -15,6 +15,7 @@ import { useBufferStore } from "@/features/editor/stores/buffer-store";
 import { useEditorStateStore } from "@/features/editor/stores/state-store";
 import { useUpdater } from "@/features/settings/hooks/use-updater";
 import { useSettingsStore } from "@/features/settings/store";
+import { useSessionTime } from "@/hooks/useSessionTime";
 import { useUIState } from "../../../../stores/ui-state-store";
 import {
   getFilenameFromPath,
@@ -25,6 +26,15 @@ import GitBranchManager from "../../../version-control/git/components/git-branch
 import { getGitStatus } from "../../../version-control/git/controllers/git";
 import { useGitStore } from "../../../version-control/git/controllers/git-store";
 import VimStatusIndicator from "../../../vim/components/vim-status-indicator";
+
+// Format time from seconds to HH:MM:SS
+function formatTime(sec: number) {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}
 
 // LSP Status Dropdown Component
 const LspStatusDropdown = ({ activeBuffer }: { activeBuffer: any }) => {
@@ -155,6 +165,7 @@ const EditorFooter = () => {
   const { gitStatus, actions } = useGitStore();
   const { available, downloading, installing, updateInfo, downloadAndInstall } = useUpdater(false);
   const cursorPosition = useEditorStateStore.use.cursorPosition();
+  const { seconds, enabled } = useSessionTime();
 
   return (
     <div className="flex min-h-[32px] items-center justify-between border-border border-t bg-secondary-bg px-2 py-1 ">
@@ -223,6 +234,13 @@ const EditorFooter = () => {
 
         {/* Vim status indicator */}
         <VimStatusIndicator />
+
+        {/* Session Time - shown only when enabled */}
+        {enabled && (
+          <div className="flex items-center gap-1 rounded px-1 py-0.5 text-[10px] text-text-lighter">
+            Session: {formatTime(seconds)}
+          </div>
+        )}
 
         {/* Update indicator */}
         {available && (

--- a/src/features/settings/components/tabs/general-settings.tsx
+++ b/src/features/settings/components/tabs/general-settings.tsx
@@ -112,6 +112,21 @@ export const GeneralSettings = () => {
         </SettingRow>
       </Section>
 
+      <Section title="Session">
+        <SettingRow
+          label="Session Time Tracking"
+          description="Track and display session time in status bar"
+        >
+          <Switch
+            checked={localStorage.getItem("sessionTimeEnabled") === "true"}
+            onChange={(checked) => {
+              localStorage.setItem("sessionTimeEnabled", checked ? "true" : "false");
+            }}
+            size="sm"
+          />
+        </SettingRow>
+      </Section>
+
       <Section title="Quick Access">
         <SettingRow label="Open Settings" description="Keyboard shortcut to open settings">
           <KeybindingBadge keys={isMac ? ["⌘", ","] : ["Ctrl", ","]} />

--- a/src/hooks/useSessionTime.ts
+++ b/src/hooks/useSessionTime.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+export function useSessionTime() {
+  const [seconds, setSeconds] = useState(0);
+  const [enabled, setEnabled] = useState(
+    () => localStorage.getItem("sessionTimeEnabled") === "true",
+  );
+
+  useEffect(() => {
+    const checkSetting = () => {
+      const val = localStorage.getItem("sessionTimeEnabled") === "true";
+      setEnabled(val);
+    };
+
+    // re-check setting every second (in case changed in settings)
+    const settingInterval = setInterval(checkSetting, 1000);
+
+    return () => clearInterval(settingInterval);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSeconds(0);
+      return;
+    }
+
+    const start = Date.now();
+
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const diff = Math.floor((now - start) / 1000);
+      setSeconds(diff);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [enabled]);
+
+  return { seconds, enabled };
+}


### PR DESCRIPTION
### Summary
This PR introduces a new Session Time Tracking feature that displays how long the user has been using Athas during the current session. The timer appears in the Status Bar and updates every second.

### Features Added
- New `useSessionTime` hook for tracking session duration
- Status Bar item showing formatted session time
- Settings toggle to enable/disable session time tracking
- Instant update when toggling the feature
- Does not modify backend or Tauri code

### Why This Is Useful
This adds a lightweight productivity metric without impacting performance and integrates cleanly with the existing settings system.

### Files Modified
- src/hooks/useSessionTime.ts
- src/features/layout/components/footer/editor-footer.tsx
- src/features/settings/components/tabs/general-settings.tsx
