### PR TITLE
Make `formatOnSave` work with biomejs formatter in vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "editor.formatOnSave": true,
+  "editor.defaultFormatter": "biomejs.biome",
   "editor.codeActionsOnSave": {
     "quickFix.biome": "explicit",
     "source.organizeImports.biome": "explicit"


### PR DESCRIPTION
Prevents linting from failing when saved files are formatted