### PR TITLE
Add ARIA accessibility descriptors for menus and tabs

### DIFF
--- a/src/features/layout/components/sidebar/sidebar-pane-selector.tsx
+++ b/src/features/layout/components/sidebar/sidebar-pane-selector.tsx
@@ -26,6 +26,9 @@ export const SidebarPaneSelector = ({
     <div className="flex gap-0.5 border-border border-b bg-secondary-bg px-1.5 py-0.5">
       <Tooltip content="File Explorer" side="right">
         <Button
+          aria-role="tab"
+          aria-selected={isFilesActive}
+          aria-label="File Explorer"
           onClick={() => onViewChange("files")}
           variant="ghost"
           size="sm"
@@ -43,6 +46,9 @@ export const SidebarPaneSelector = ({
       {coreFeatures.search && (
         <Tooltip content="Search" side="right">
           <Button
+            aria-role="tab"
+            aria-selected={isSearchViewActive}
+            aria-label="Search"
             onClick={() => onViewChange("search")}
             variant="ghost"
             size="sm"
@@ -61,6 +67,9 @@ export const SidebarPaneSelector = ({
       {coreFeatures.git && (
         <Tooltip content="Source Control" side="right">
           <Button
+            aria-role="tab"
+            aria-selected={isGitViewActive}
+            aria-label="Git Source Control"
             onClick={() => onViewChange("git")}
             variant="ghost"
             size="sm"
@@ -79,6 +88,9 @@ export const SidebarPaneSelector = ({
       {coreFeatures.remote && !isRemoteWindow && (
         <Tooltip content="Remote Connections" side="right">
           <Button
+            aria-role="tab"
+            aria-selected={isRemoteViewActive}
+            aria-label="Remote Connections"
             onClick={() => onViewChange("remote")}
             variant="ghost"
             size="sm"

--- a/src/features/window/components/project-tabs.tsx
+++ b/src/features/window/components/project-tabs.tsx
@@ -334,6 +334,7 @@ const ProjectTabs = () => {
                 <div className="absolute top-1 bottom-1 left-0 z-20 w-0.5 bg-accent" />
               )}
               <button
+                role="tab"
                 ref={(el) => {
                   tabRefs.current[index] = el;
                 }}

--- a/src/features/window/menu-bar/index.tsx
+++ b/src/features/window/menu-bar/index.tsx
@@ -43,7 +43,7 @@ const CustomMenuBar = ({ activeMenu, setActiveMenu }: Props) => {
   const menus = useMemo(
     () => ({
       File: (
-        <Menu>
+        <Menu aria-label="File">
           <MenuItem shortcut="Ctrl+N" onClick={() => handleClickEmit("menu_new_file")}>
             New File
           </MenuItem>
@@ -69,7 +69,7 @@ const CustomMenuBar = ({ activeMenu, setActiveMenu }: Props) => {
         </Menu>
       ),
       Edit: (
-        <Menu>
+        <Menu aria-label="Edit">
           <MenuItem shortcut="Ctrl+Z" onClick={() => handleClickEmit("menu_undo")}>
             Undo
           </MenuItem>
@@ -95,7 +95,7 @@ const CustomMenuBar = ({ activeMenu, setActiveMenu }: Props) => {
         </Menu>
       ),
       View: (
-        <Menu>
+        <Menu aria-label="View">
           <MenuItem shortcut="Ctrl+B" onClick={() => handleClickEmit("menu_toggle_sidebar")}>
             Toggle Sidebar
           </MenuItem>
@@ -128,7 +128,7 @@ const CustomMenuBar = ({ activeMenu, setActiveMenu }: Props) => {
         </Menu>
       ),
       Go: (
-        <Menu>
+        <Menu aria-label="Go">
           <MenuItem shortcut="Ctrl+P" onClick={() => handleClickEmit("menu_go_to_file")}>
             Go to File
           </MenuItem>
@@ -145,7 +145,7 @@ const CustomMenuBar = ({ activeMenu, setActiveMenu }: Props) => {
         </Menu>
       ),
       Window: (
-        <Menu>
+        <Menu aria-label="Window">
           <MenuItem
             shortcut="Alt+F9"
             onClick={async () => {
@@ -183,7 +183,7 @@ const CustomMenuBar = ({ activeMenu, setActiveMenu }: Props) => {
         </Menu>
       ),
       Help: (
-        <Menu>
+        <Menu aria-label="Help">
           <MenuItem onClick={() => handleClickEmit("menu_help")}>Help</MenuItem>
           <MenuItem separator />
           <MenuItem onClick={() => handleClickEmit("menu_about_athas")}>About Athas</MenuItem>

--- a/src/features/window/menu-bar/menu-item.tsx
+++ b/src/features/window/menu-bar/menu-item.tsx
@@ -36,6 +36,7 @@ const MenuItem = ({ children, shortcut, onClick, separator }: Props) => {
 
   return (
     <button
+      role="menuitem"
       className="flex w-full cursor-pointer items-center justify-between px-3 py-1.5 text-text text-xs hover:bg-hover"
       onClick={onClick}
     >

--- a/src/features/window/menu-bar/menu.tsx
+++ b/src/features/window/menu-bar/menu.tsx
@@ -1,12 +1,16 @@
-import type { ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
-interface Props {
+interface Props extends ComponentPropsWithoutRef<"div"> {
   children: ReactNode;
 }
 
-const Menu = ({ children }: Props) => {
+const Menu = ({ children, ...props }: Props) => {
   return (
-    <div className="w-max min-w-48 rounded-md border border-border bg-primary-bg py-1 shadow-lg">
+    <div
+      role="menu"
+      className="w-max min-w-48 rounded-md border border-border bg-primary-bg shadow-lg"
+      {...props}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

<!-- Describe the changes made in the PR. -->

This PR makes small UI and accessibility improvements to the menu component.

- Adds aria-role="tab" to sidebar tab buttons
- Adds aria-role="tab" to project tab buttons
- Adds aria-role="menu" and aria-role="menuitem" to respective components `<Menu>` and `<MenuItem>`
- `<Menu>` now `extends ComponentPropsWithoutRef<"div">` to be able to pass `aria-label` as props through `<Menu>`
- _Style:_ Removes `py-1` from `<Menu>` component as it leads to unnecessary top & bottom padding which looks wonky. An alternative is to replace it with `p-1`

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->

Before: 
<img width="226" height="297" alt="image" src="https://github.com/user-attachments/assets/86706e78-562e-4ef7-b917-ecb16d8a22e8" />

After:
<img width="344" height="282" alt="image" src="https://github.com/user-attachments/assets/629f635b-af24-4371-a9c3-ea179d1a4dbb" />

`p-1` alternative:
<img width="228" height="292" alt="image" src="https://github.com/user-attachments/assets/6112de85-6faa-45bf-a856-1b90e3acf13c" />
