### PR TITLE
Fix autosave functionality and dirty state logic

### DIFF
--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -52,6 +52,7 @@ export function Editor({ className }: EditorProps) {
   } = useEditorStateStore.use.actions();
   const cursorPosition = useEditorStateStore.use.cursorPosition();
   const multiCursorState = useEditorStateStore.use.multiCursorState();
+  const onChange = useEditorStateStore.use.onChange();
 
   const fontSize = useEditorSettingsStore.use.fontSize();
   const fontFamily = useEditorSettingsStore.use.fontFamily();
@@ -139,6 +140,7 @@ export function Editor({ className }: EditorProps) {
       }
 
       updateBufferContent(bufferId, newActualContent);
+      onChange(newActualContent);
 
       const selectionStart = inputRef.current.selectionStart;
       const virtualLines = splitLines(newVirtualContent);

--- a/src/features/editor/stores/buffer-store.ts
+++ b/src/features/editor/stores/buffer-store.ts
@@ -18,6 +18,7 @@ export interface Buffer {
   path: string;
   name: string;
   content: string;
+  savedContent: string;
   isDirty: boolean;
   isVirtual: boolean;
   isPinned: boolean;
@@ -218,6 +219,7 @@ export const useBufferStore = createSelectors(
             path,
             name,
             content,
+            savedContent: content,
             isDirty: false,
             isVirtual,
             isPinned: false,
@@ -356,6 +358,7 @@ export const useBufferStore = createSelectors(
             path,
             name,
             content: "", // External editor buffers don't have content
+            savedContent: "",
             isDirty: false,
             isVirtual: false,
             isPinned: false,
@@ -425,6 +428,7 @@ export const useBufferStore = createSelectors(
             path,
             name: displayName,
             content: "",
+            savedContent: "",
             isDirty: false,
             isVirtual: true,
             isPinned: false,
@@ -599,7 +603,12 @@ export const useBufferStore = createSelectors(
                 buffer.diffData = diffData;
               }
               if (!buffer.isVirtual) {
-                buffer.isDirty = markDirty;
+                if (!markDirty) {
+                  buffer.savedContent = content;
+                  buffer.isDirty = false;
+                } else {
+                  buffer.isDirty = content !== buffer.savedContent;
+                }
               }
               // Keep tokens - syntax highlighter will update them automatically
               // The 16ms debounce ensures smooth updates without glitches
@@ -621,6 +630,9 @@ export const useBufferStore = createSelectors(
             const buffer = state.buffers.find((b) => b.id === bufferId);
             if (buffer) {
               buffer.isDirty = isDirty;
+              if (!isDirty) {
+                buffer.savedContent = buffer.content;
+              }
             }
           });
         },


### PR DESCRIPTION
# Pull Request

This PR addresses critical issues with the editor's data persistence and state management. It fixes a bug where autosave was failing to trigger and corrects the `dirty state` logic to accurately reflect unsaved changes, ensuring the indicator clears when content matches the saved version.

## Description

- Fixed a critical bug where the autosave mechanism was not triggering because the `onChange` callback was not being called in the `Editor`
- Refactored `BufferStore` to include a `savedContent` field for each buffer.
- Updated `updateBufferContent` and `markBufferDirty` to use `savedContent` for accurate dirty state calculation. This resolves the issue where the dirty indicator would remain active even after reverting changes to the original state.
- Ensured that `onChange` is correctly propagated from `useEditorStateStore` to the `Editor`

## Screenshots/Videos

<!-- If applicable, add screenshots or screen recordings to help explain your changes. -->


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes # Fixes #


