### PR TITLE
Fixed Bug With drag region for the window

### DIFF
--- a/src/features/window/custom-title-bar.tsx
+++ b/src/features/window/custom-title-bar.tsx
@@ -179,7 +179,7 @@ const CustomTitleBar = ({ showMinimal = false, onOpenSettings }: CustomTitleBarP
       )}
 
       {/* Left side */}
-      <div className="flex flex-1 items-center px-2">
+      <div data-tauri-drag-region className="flex flex-1 items-center px-2">
         {/* Menu bar button */}
         {!settings.nativeMenuBar && settings.compactMenuBar && (
           <Tooltip content="Menu" side="bottom">


### PR DESCRIPTION
# Pull Request

<!-- A clear and concise description of what this PR does and why it's needed. -->

## Description

I downloaded athas today to my Debian machine and noticed I couldn't really drag the window around. I looked at the Tauri documentation for `data-tauri-drag-region` and it says in a Note: 

```
"data-tauri-drag-region" will only work on the element to which it is directly applied. 
If you want the drag behavior to apply to child elements as well, you’ll need to add it 
to each child individually.

This behavior is preserved so that interactive elements like buttons and inputs can function properly.
```

With that information I inspected the custom-title-bar and noticed the div with `data-tauri-drag-region` was mostly filled by the next child div labeled `{/* Left side */}`. Adding `data-tauri-drag-region` to this div fixed the issue by allowing the child that fills up moist of the space to also act as the drag region. The menu still works as expected.

<!-- Describe the changes made in the PR. -->

- Added `data-tauri-drag-region` to the Left side div in `custom-title-bar.tsx`


## Related Issues

<!-- If this PR closes any issues, use the keyword 'closes' followed by the issue number -->

Closes #450

