### PR TITLE
Fix traffic lights for macOS 26

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,8 +27,8 @@
         "minHeight": 400,
         "shadow": true,
         "trafficLightPosition": {
-          "x": 20,
-          "y": 22
+          "x": 18.5,
+          "y": 20.5
         }
       }
     ],

--- a/src/features/window/custom-title-bar.tsx
+++ b/src/features/window/custom-title-bar.tsx
@@ -127,7 +127,7 @@ const CustomTitleBar = ({ showMinimal = false, onOpenSettings }: CustomTitleBarP
         )}
 
         {/* macOS traffic light space holder */}
-        <div className="flex items-center space-x-2 pl-4" />
+        <div className="flex items-center space-x-2 pl-3" />
 
         {/* Center - Project tabs for macOS */}
         <div className="-translate-x-1/2 pointer-events-auto absolute left-1/2 flex transform items-center">


### PR DESCRIPTION
# Pull Request

Fixes traffic light positioning for macOS 26


## Screenshots/Videos
### Before:
<img width="327" height="179" alt="image" src="https://github.com/user-attachments/assets/a4f7cccf-7ad1-403a-9b13-8408a7ec2e68" />

### After:
<img width="255" height="128" alt="image" src="https://github.com/user-attachments/assets/f515d4e8-a62b-4731-b59f-017059a7548a" />