### PR TITLE
Fix link format in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Athas is a lightweight, cross-platform code editor designed for developers who w
 
 ## Getting Started
 
-- [Installation](installation) - Download and install Athas
+- [Installation](/docs/installation) - Download and install Athas
 
 ## Technology Stack
 


### PR DESCRIPTION
Fix broken “Installation” link that was resolving to /installation which returns a 404. Use an absolute path so it correctly points to /docs/installation.
