### PR TITLE
Auto-refresh Source Control when view becomes active

### DIFF
--- a/src/features/layout/components/sidebar/main-sidebar.tsx
+++ b/src/features/layout/components/sidebar/main-sidebar.tsx
@@ -114,7 +114,11 @@ export const MainSidebar = memo(() => {
       <div className="flex-1 overflow-hidden">
         {settings.coreFeatures.git && (
           <div className={cn("h-full", !isGitViewActive && "hidden")}>
-            <GitView repoPath={rootFolderPath} onFileSelect={handleFileSelect} />
+            <GitView
+              repoPath={rootFolderPath}
+              onFileSelect={handleFileSelect}
+              isActive={isGitViewActive}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Automatically refreshes git status when clicking on Source Control in the sidebar
- No longer requires manual refresh click to see latest changes

## Test plan
- [ ] Open a git repository
- [ ] Make some file changes
- [ ] Navigate to Files view
- [ ] Click on Source Control
- [ ] Verify changes appear immediately without clicking refresh