### PR TITLE
Limit horizontal scroll to visible content overflow

### DIFF
--- a/src/features/editor/utils/lines.ts
+++ b/src/features/editor/utils/lines.ts
@@ -18,3 +18,120 @@ export function isMarkdownFile(filePath: string): boolean {
   const extension = filePath.split(".").pop()?.toLowerCase();
   return extension === "md" || extension === "markdown";
 }
+
+// Reusable DOM element for text measurement (more accurate than canvas)
+let measureElement: HTMLSpanElement | null = null;
+
+function getMeasureElement(): HTMLSpanElement {
+  if (!measureElement) {
+    measureElement = document.createElement("span");
+    measureElement.style.position = "absolute";
+    measureElement.style.visibility = "hidden";
+    measureElement.style.whiteSpace = "pre";
+    measureElement.style.top = "-9999px";
+    measureElement.style.left = "-9999px";
+    document.body.appendChild(measureElement);
+  }
+  return measureElement;
+}
+
+/**
+ * Measure the width of a text string in pixels using DOM measurement
+ * @param text The text to measure
+ * @param fontSize Font size in pixels
+ * @param fontFamily Font family string
+ * @param tabSize Tab size for tab character expansion
+ */
+export function measureTextWidth(
+  text: string,
+  fontSize: number,
+  fontFamily: string,
+  tabSize: number,
+): number {
+  const element = getMeasureElement();
+  element.style.fontSize = `${fontSize}px`;
+  element.style.fontFamily = fontFamily;
+  element.style.tabSize = String(tabSize);
+
+  element.textContent = text;
+  return element.getBoundingClientRect().width;
+}
+
+/**
+ * Calculate the maximum width of lines within a range
+ * @param lines Array of line strings
+ * @param startLine Start of range (inclusive)
+ * @param endLine End of range (exclusive)
+ * @param fontSize Font size in pixels
+ * @param fontFamily Font family string
+ * @param tabSize Tab size for tab character expansion
+ */
+/**
+ * Smoothly animate an element's scrollLeft to a target value
+ * @param element The element to animate
+ * @param targetScrollLeft Target scrollLeft value
+ * @param duration Animation duration in ms
+ * @returns Cleanup function to cancel the animation
+ */
+export function animateScrollLeft(
+  element: HTMLElement,
+  targetScrollLeft: number,
+  duration: number = 150,
+): () => void {
+  const startScrollLeft = element.scrollLeft;
+  const distance = targetScrollLeft - startScrollLeft;
+
+  if (distance === 0) return () => {};
+
+  const startTime = performance.now();
+  let animationId: number | null = null;
+
+  const easeOutCubic = (t: number): number => 1 - (1 - t) ** 3;
+
+  const animate = (currentTime: number) => {
+    const elapsed = currentTime - startTime;
+    const progress = Math.min(elapsed / duration, 1);
+    const easedProgress = easeOutCubic(progress);
+
+    element.scrollLeft = startScrollLeft + distance * easedProgress;
+
+    if (progress < 1) {
+      animationId = requestAnimationFrame(animate);
+    }
+  };
+
+  animationId = requestAnimationFrame(animate);
+
+  return () => {
+    if (animationId !== null) {
+      cancelAnimationFrame(animationId);
+    }
+  };
+}
+
+export function getMaxVisibleLineWidth(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+  fontSize: number,
+  fontFamily: string,
+  tabSize: number,
+): { maxWidth: number; longestLineIndex: number; longestLineLength: number } {
+  let maxWidth = 0;
+  let longestLineIndex = startLine;
+  const actualEnd = Math.min(endLine, lines.length);
+
+  for (let i = startLine; i < actualEnd; i++) {
+    const lineWidth = measureTextWidth(lines[i], fontSize, fontFamily, tabSize);
+    if (lineWidth > maxWidth) {
+      maxWidth = lineWidth;
+      longestLineIndex = i;
+    }
+  }
+
+  return {
+    maxWidth,
+    longestLineIndex,
+    longestLineLength: lines[longestLineIndex]?.length ?? 0,
+  };
+}


### PR DESCRIPTION
## Summary

- Horizontal scrolling is now only enabled when lines in the current viewport actually overflow
- Previously, users could scroll horizontally even when viewing short lines, as long as the file contained long lines elsewhere
- When vertical scrolling brings shorter lines into view, the horizontal scroll smoothly animates back

## Changes

- Add DOM-based text measurement utilities (`measureTextWidth`, `getMaxVisibleLineWidth`) for accurate line width calculation
- Modify wheel handler to calculate actual visible lines (without tokenization buffer) and only allow horizontal scroll when they overflow
- Add `animateScrollLeft` utility with 150ms ease-out cubic animation for smooth transitions
- Automatically clamp/reset horizontal scroll position when viewport changes

## Test plan

- [ ] Open a file with some long lines and some short lines
- [ ] Scroll to short lines - horizontal scroll should be disabled
- [ ] Scroll to long lines that extend past the viewport - horizontal scroll should work
- [ ] While scrolled horizontally, scroll vertically to shorter lines - should see smooth animation back to 0