### PR TITLE
Fix sticky folder background transparency in file tree

### DIFF
--- a/src/features/file-explorer/views/file-tree.css
+++ b/src/features/file-explorer/views/file-tree.css
@@ -35,6 +35,7 @@
 .file-tree-item-dir {
   position: sticky !important;
   top: calc(var(--depth, 0) * 22px) !important;
+  z-index: calc(100 - var(--depth, 0)) !important;
 }
 
 /* Ensure file tree content wrapper stretches to full scrollable area */
@@ -67,7 +68,7 @@
 }
 
 /* Sticky folders need solid background to hide text beneath */
-.file-tree-container .file-tree-item-dir {
+.file-tree-container .file-tree-item button.file-tree-item-dir {
   background-color: var(--color-secondary-bg) !important;
   width: 100% !important;
   min-width: 100% !important;
@@ -75,11 +76,11 @@
   justify-content: flex-start !important;
 }
 
-.file-tree-container .file-tree-item-dir:hover {
+.file-tree-container .file-tree-item button.file-tree-item-dir:hover {
   background-color: var(--color-hover) !important;
 }
 
-.file-tree-container .file-tree-item-dir.bg-selected {
+.file-tree-container .file-tree-item button.file-tree-item-dir.bg-selected {
   background-color: var(--color-selected) !important;
 }
 

--- a/src/features/file-explorer/views/file-tree.tsx
+++ b/src/features/file-explorer/views/file-tree.tsx
@@ -655,7 +655,8 @@ const FileTree = ({
             className={cn(
               "flex min-h-[20px] w-full min-w-max cursor-pointer",
               "select-none items-center gap-1.5",
-              "whitespace-nowrap border-none bg-transparent",
+              "whitespace-nowrap border-none",
+              !file.isDir && "bg-transparent",
               "ui-font px-1.5 py-0.5 text-left text-text text-xs",
               "shadow-none outline-none transition-colors duration-150",
               "hover:bg-hover focus:outline-none",


### PR DESCRIPTION
## Summary
- Add depth-based z-index to sticky folders so parent folders layer above children
- Fix CSS selector specificity for sticky folder background colors  
- Only apply bg-transparent to file items, not directories

## Known Issues
There is still some minor content bleeding through sticky headers that needs further investigation.

## Test plan
- [ ] Open a deeply nested folder structure in the file explorer
- [ ] Scroll through the file tree and verify sticky folder headers hide content beneath them
- [ ] Verify parent folders appear above child folders when multiple are sticky