### PR TITLE
Fix tokenization lag and visual flashing during typing

### DIFF
--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -118,8 +118,9 @@ export function Editor({
     lineHeight,
   });
 
-  const { tokens, tokenize, forceFullTokenize } = useTokenizer({
+  const { tokens, tokenizedContent, tokenize, forceFullTokenize } = useTokenizer({
     filePath,
+    bufferId: bufferId || undefined,
     incremental: true,
     enabled: hasSyntaxHighlighting,
   });
@@ -181,23 +182,10 @@ export function Editor({
         setCursorPosition(position);
       }
 
-      if (hasSyntaxHighlighting) {
-        // Tokenize the content that will be displayed (full tokenize on input for accuracy)
-        const contentToTokenize = foldTransform.hasActiveFolds
-          ? newVirtualContent
-          : newActualContent;
-        tokenize(contentToTokenize);
-      }
+      // Tokenization is handled by the debounced useEffect that watches buffer content
+      // This avoids double tokenization and provides better performance when typing
     },
-    [
-      bufferId,
-      updateBufferContent,
-      setCursorPosition,
-      tokenize,
-      hasSyntaxHighlighting,
-      content,
-      foldTransform,
-    ],
+    [bufferId, updateBufferContent, setCursorPosition, content, foldTransform, onChange],
   );
 
   const editorOps = useEditorOperations({
@@ -388,7 +376,7 @@ export function Editor({
             inputRef.current.selectionEnd = primaryCursor.position.offset;
           }
 
-          tokenize(newContent);
+          // Tokenization handled by debounced useEffect watching buffer content
           return;
         }
 
@@ -420,7 +408,7 @@ export function Editor({
             inputRef.current.selectionEnd = primaryCursor.position.offset;
           }
 
-          tokenize(newContent);
+          // Tokenization handled by debounced useEffect watching buffer content
           return;
         }
       }
@@ -644,32 +632,29 @@ export function Editor({
     };
   }, []);
 
-  // Debounced tokenization to avoid blocking during scroll
-  const tokenizeTimerRef = useRef<NodeJS.Timeout | null>(null);
+  // Tokenization scheduled via requestAnimationFrame for smooth updates
+  const tokenizeRafRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (!buffer?.content || !buffer?.path) return;
 
     // Clear any pending tokenization
-    if (tokenizeTimerRef.current) {
-      clearTimeout(tokenizeTimerRef.current);
+    if (tokenizeRafRef.current !== null) {
+      cancelAnimationFrame(tokenizeRafRef.current);
     }
 
     const contentToTokenize = foldTransform.hasActiveFolds ? displayContent : buffer.content;
 
-    // If actively scrolling, debounce the tokenization
-    if (isScrollingRef.current) {
-      tokenizeTimerRef.current = setTimeout(() => {
-        tokenize(contentToTokenize, viewportRange);
-      }, 200);
-    } else {
-      // Not scrolling, tokenize immediately
+    // Use requestAnimationFrame for smooth tokenization
+    // This batches updates to the next frame without visible delay
+    tokenizeRafRef.current = requestAnimationFrame(() => {
       tokenize(contentToTokenize, viewportRange);
-    }
+      tokenizeRafRef.current = null;
+    });
 
     return () => {
-      if (tokenizeTimerRef.current) {
-        clearTimeout(tokenizeTimerRef.current);
+      if (tokenizeRafRef.current !== null) {
+        cancelAnimationFrame(tokenizeRafRef.current);
       }
     };
   }, [
@@ -728,9 +713,9 @@ export function Editor({
       if (inputRef.current) {
         inputRef.current.value = newContent;
       }
-      tokenize(newContent);
+      // Tokenization handled by debounced useEffect watching buffer content
     },
-    [lines, bufferId, updateBufferContent, tokenize],
+    [lines, bufferId, updateBufferContent],
   );
 
   if (!buffer) return null;
@@ -761,7 +746,7 @@ export function Editor({
         {hasSyntaxHighlighting && (
           <HighlightLayer
             ref={highlightRef}
-            content={displayContent}
+            content={tokenizedContent || displayContent}
             tokens={tokens}
             fontSize={fontSize}
             fontFamily={fontFamily}

--- a/src/features/editor/components/layers/highlight-layer.tsx
+++ b/src/features/editor/components/layers/highlight-layer.tsx
@@ -28,6 +28,7 @@ const Line = memo<LineProps>(
       const result: ReactNode[] = [];
       let lastIndex = 0;
       let spanKey = 0;
+      let lastTokenClass: string | undefined;
 
       for (const token of tokens) {
         // Calculate token position relative to this line
@@ -44,10 +45,14 @@ const Line = memo<LineProps>(
           continue;
         }
 
-        // Add text before token
+        // Add text before token - use last token's class to avoid flash
         if (tokenStartInLine > lastIndex) {
           const text = lineContent.substring(lastIndex, Math.max(lastIndex, tokenStartInLine));
-          result.push(<span key={`${lineIndex}-${spanKey++}`}>{text}</span>);
+          result.push(
+            <span key={`${lineIndex}-${spanKey++}`} className={lastTokenClass}>
+              {text}
+            </span>,
+          );
         }
 
         // Add token (start from lastIndex if token overlaps with previous)
@@ -61,12 +66,18 @@ const Line = memo<LineProps>(
         );
 
         lastIndex = end;
+        lastTokenClass = token.class_name;
       }
 
-      // Add remaining text
+      // Add remaining text - use the last token's class to avoid white flash
+      // This handles the case where content is added but tokens haven't updated yet
       if (lastIndex < lineContent.length) {
         const text = lineContent.substring(lastIndex);
-        result.push(<span key={`${lineIndex}-${spanKey++}`}>{text}</span>);
+        result.push(
+          <span key={`${lineIndex}-${spanKey++}`} className={lastTokenClass}>
+            {text}
+          </span>,
+        );
       }
 
       return result;

--- a/src/features/editor/lib/wasm-parser/types.ts
+++ b/src/features/editor/lib/wasm-parser/types.ts
@@ -2,7 +2,7 @@
  * Types for WASM-based Tree-sitter parsing
  */
 
-import type { Language, Parser, Query, Tree } from "web-tree-sitter";
+import type { Edit, Language, Parser, Query, Tree } from "web-tree-sitter";
 
 export interface HighlightToken {
   type: string;
@@ -26,6 +26,24 @@ export interface LoadedParser {
 }
 
 export interface ParseResult {
+  tokens: HighlightToken[];
+  tree: Tree;
+}
+
+/**
+ * Options for incremental parsing with Tree-sitter
+ */
+export interface IncrementalParseOptions {
+  /** The previous parse tree to use for incremental parsing */
+  previousTree?: Tree;
+  /** The edit that was applied to transform the old content to new content */
+  edit?: Edit;
+}
+
+/**
+ * Result of tokenization including the parse tree for caching
+ */
+export interface TokenizeResult {
   tokens: HighlightToken[];
   tree: Tree;
 }

--- a/src/features/editor/stores/tree-cache-store.ts
+++ b/src/features/editor/stores/tree-cache-store.ts
@@ -1,0 +1,115 @@
+/**
+ * Tree Cache Store
+ * Stores Tree-sitter parse trees per buffer for incremental parsing
+ */
+
+import type { Tree } from "web-tree-sitter";
+import { create } from "zustand";
+import { createSelectors } from "@/utils/zustand-selectors";
+
+export interface TreeCacheEntry {
+  tree: Tree;
+  contentLength: number; // Simple hash for staleness detection
+  languageId: string;
+  lastUpdated: number;
+}
+
+interface TreeCacheState {
+  trees: Map<string, TreeCacheEntry>;
+
+  actions: {
+    setTree: (bufferId: string, tree: Tree, contentLength: number, languageId: string) => void;
+    getTree: (bufferId: string) => TreeCacheEntry | undefined;
+    clearTree: (bufferId: string) => void;
+    clearAllTrees: () => void;
+  };
+}
+
+export const useTreeCacheStore = createSelectors(
+  create<TreeCacheState>()((set, get) => ({
+    trees: new Map(),
+
+    actions: {
+      setTree: (bufferId, tree, contentLength, languageId) => {
+        set((state) => {
+          const newMap = new Map(state.trees);
+          // Delete old tree to free memory
+          const oldEntry = newMap.get(bufferId);
+          if (oldEntry?.tree) {
+            try {
+              oldEntry.tree.delete();
+            } catch {
+              // Tree may already be deleted
+            }
+          }
+          newMap.set(bufferId, {
+            tree,
+            contentLength,
+            languageId,
+            lastUpdated: Date.now(),
+          });
+          return { trees: newMap };
+        });
+      },
+
+      getTree: (bufferId) => {
+        return get().trees.get(bufferId);
+      },
+
+      clearTree: (bufferId) => {
+        set((state) => {
+          const newMap = new Map(state.trees);
+          const entry = newMap.get(bufferId);
+          if (entry?.tree) {
+            try {
+              entry.tree.delete();
+            } catch {
+              // Tree may already be deleted
+            }
+          }
+          newMap.delete(bufferId);
+          return { trees: newMap };
+        });
+      },
+
+      clearAllTrees: () => {
+        const { trees } = get();
+        for (const entry of trees.values()) {
+          if (entry?.tree) {
+            try {
+              entry.tree.delete();
+            } catch {
+              // Tree may already be deleted
+            }
+          }
+        }
+        set({ trees: new Map() });
+      },
+    },
+  })),
+);
+
+// Subscribe to buffer store to clean up trees when buffers are closed
+// This is done lazily to avoid circular dependency issues
+let subscribed = false;
+
+export function initTreeCacheSubscription() {
+  if (subscribed) return;
+  subscribed = true;
+
+  // Dynamically import to avoid circular dependency
+  import("./buffer-store").then(({ useBufferStore }) => {
+    useBufferStore.subscribe((state, prevState) => {
+      const currentBufferIds = new Set(state.buffers.map((b) => b.id));
+      const previousBufferIds = new Set(prevState.buffers.map((b) => b.id));
+
+      // Find closed buffers
+      for (const bufferId of previousBufferIds) {
+        if (!currentBufferIds.has(bufferId)) {
+          // Buffer was closed, clean up its tree
+          useTreeCacheStore.getState().actions.clearTree(bufferId);
+        }
+      }
+    });
+  });
+}

--- a/src/features/editor/utils/tree-sitter-edit.ts
+++ b/src/features/editor/utils/tree-sitter-edit.ts
@@ -1,0 +1,127 @@
+/**
+ * Tree-sitter Edit Calculation Utility
+ * Calculates the Edit object needed for incremental parsing
+ */
+
+import type { Edit, Point } from "web-tree-sitter";
+
+/**
+ * Convert a byte offset to a Point (row, column)
+ */
+export function offsetToPoint(content: string, offset: number): Point {
+  let row = 0;
+  let column = 0;
+
+  for (let i = 0; i < offset && i < content.length; i++) {
+    if (content[i] === "\n") {
+      row++;
+      column = 0;
+    } else {
+      column++;
+    }
+  }
+
+  return { row, column };
+}
+
+/**
+ * Find the length of the common prefix between two strings
+ */
+function findCommonPrefixLength(a: string, b: string): number {
+  const minLength = Math.min(a.length, b.length);
+  let i = 0;
+  while (i < minLength && a[i] === b[i]) {
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Find the length of the common suffix between two strings,
+ * starting after a given offset (to avoid overlapping with prefix)
+ */
+function findCommonSuffixLength(a: string, b: string, prefixLength: number): number {
+  const maxSuffixA = a.length - prefixLength;
+  const maxSuffixB = b.length - prefixLength;
+  const maxSuffix = Math.min(maxSuffixA, maxSuffixB);
+
+  let i = 0;
+  while (i < maxSuffix && a[a.length - 1 - i] === b[b.length - 1 - i]) {
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Calculate the Tree-sitter Edit object from old and new content.
+ *
+ * Returns null if:
+ * - Content hasn't changed
+ * - Edit calculation fails for any reason
+ *
+ * @param oldContent The previous content
+ * @param newContent The new content after the edit
+ * @returns Edit object for Tree-sitter, or null if calculation fails
+ */
+export function calculateEdit(oldContent: string, newContent: string): Edit | null {
+  // If content is the same, no edit needed
+  if (oldContent === newContent) {
+    return null;
+  }
+
+  // Find common prefix
+  const prefixLength = findCommonPrefixLength(oldContent, newContent);
+
+  // Find common suffix (after prefix to avoid overlap)
+  const suffixLength = findCommonSuffixLength(oldContent, newContent, prefixLength);
+
+  // Calculate edit positions
+  const startIndex = prefixLength;
+  const oldEndIndex = oldContent.length - suffixLength;
+  const newEndIndex = newContent.length - suffixLength;
+
+  // Sanity check: ensure indices are valid
+  if (startIndex > oldEndIndex || startIndex > newEndIndex) {
+    return null;
+  }
+
+  // Calculate Point positions
+  const startPosition = offsetToPoint(oldContent, startIndex);
+  const oldEndPosition = offsetToPoint(oldContent, oldEndIndex);
+  const newEndPosition = offsetToPoint(newContent, newEndIndex);
+
+  return {
+    startIndex,
+    oldEndIndex,
+    newEndIndex,
+    startPosition,
+    oldEndPosition,
+    newEndPosition,
+  };
+}
+
+/**
+ * Quick check if an edit is simple (small change that benefits from incremental parsing)
+ * Returns false for large changes where full reparse might be faster
+ */
+export function isSimpleEdit(oldContent: string, newContent: string): boolean {
+  const lengthDiff = Math.abs(oldContent.length - newContent.length);
+
+  // If the change is more than 1000 characters, consider it complex
+  if (lengthDiff > 1000) {
+    return false;
+  }
+
+  // Calculate edit to check the actual change size
+  const edit = calculateEdit(oldContent, newContent);
+  if (!edit) {
+    return false;
+  }
+
+  // If the changed region is more than 500 bytes, consider it complex
+  const oldChangeSize = edit.oldEndIndex - edit.startIndex;
+  const newChangeSize = edit.newEndIndex - edit.startIndex;
+  const maxChangeSize = Math.max(oldChangeSize, newChangeSize);
+
+  return maxChangeSize <= 500;
+}


### PR DESCRIPTION
## Summary
- Remove double tokenization that was causing lag when holding keys
- Use requestAnimationFrame for smoother debounced tokenization
- Synchronize content with tokens to prevent white flashes during typing
- Add infrastructure for Tree-sitter incremental parsing (for future use)

## Test plan
- [x] Hold down a key and verify no lag
- [x] Type quickly and verify no white flashing on tokens
- [x] Verify syntax highlighting still works correctly