### PR TITLE
Add the ability to favorite commands in the command palette

### DIFF
--- a/src/features/command-palette/store.ts
+++ b/src/features/command-palette/store.ts
@@ -8,6 +8,9 @@ interface ActionsStore {
   lastEnteredActionsStack: string[];
   pushAction: (actionId: string) => void;
   clearStack: () => void;
+
+  favoritedActions: string[];
+  toggleFavoriteAction: (actionId: string) => boolean;
 }
 
 export const useActionsStore = createSelectors(
@@ -15,6 +18,7 @@ export const useActionsStore = createSelectors(
     persist(
       (set) => ({
         lastEnteredActionsStack: [],
+        favoritedActions: [],
 
         pushAction: (actionId) => {
           set((state) => {
@@ -31,6 +35,24 @@ export const useActionsStore = createSelectors(
 
         clearStack: () => {
           set(() => ({ lastEnteredActionsStack: [] }));
+        },
+
+        toggleFavoriteAction: (actionId) => {
+          let didFavorite = false;
+
+          set((state) => {
+            const alreadyFav = state.favoritedActions.includes(actionId);
+
+            didFavorite = !alreadyFav; // true if adding, false if removing
+
+            const newFavActions = alreadyFav
+              ? state.favoritedActions.filter((id) => id !== actionId)
+              : [...state.favoritedActions, actionId];
+
+            return { favoritedActions: newFavActions };
+          });
+
+          return didFavorite;
         },
       }),
       { name: "actions-storage" },

--- a/src/ui/command.tsx
+++ b/src/ui/command.tsx
@@ -79,10 +79,11 @@ export const CommandHeader = ({
 interface CommandListProps {
   children: React.ReactNode;
   ref?: React.Ref<HTMLDivElement>;
+  onFocus?: (e: React.FocusEvent) => void;
 }
 
-export const CommandList = ({ children, ref }: CommandListProps) => (
-  <div ref={ref} className="custom-scrollbar-thin flex-1 overflow-y-auto p-1">
+export const CommandList = ({ children, ref, onFocus }: CommandListProps) => (
+  <div ref={ref} className="custom-scrollbar-thin flex-1 overflow-y-auto p-1" onFocus={onFocus}>
     {children}
   </div>
 );


### PR DESCRIPTION
# Command Favoriting & UX Optimization

## Summary
This PR introduces the ability to **favorite commands** in the command palette and significantly improves keyboard navigation performance by optimizing the scroll logic and focus management.

## Key Changes

### 1. Command Favoriting
- Added a "Star" toggle on each command item to manage favorites.
- Creates a new hierarchy for command ordering: `Favorited > Recently Used > General`.
- **UX:** Favoriting/unfavoriting does not trigger an immediate reorder to prevent the UI from "jumping" while the user is interacting. Reordering occurs upon the next palette open.

### 2. Enhanced Keyboard Navigation
- **Smart Focus:** Tabbing into the `resultsRef` now jumps directly to the currently selected command rather than the first item in the list.
- **Inner-Item Navigation:** Users can now Tab forward into the command item to reach the Favorite button.
- **Quick Escape:** `Shift + Tab`  returns focus to the search input as a quick reset.

### 3. Scroll Performance Optimization
- Replaced the previous smooth-scroll with a `requestAnimationFrame` (rAF) implementation using refs.
- **Problem solved:** Holding down arrow keys previously triggered ~60 scroll events per second, causing significant visual lag 
- **Solution:** By canceling pending animation frames, the scroll now remains "locked" to the frame rate, resulting in an instant, responsive feel even when holding down keys.

## Demonstration
https://github.com/user-attachments/assets/56e0a141-30f0-4e02-be28-de7bd9da2d00