### PR TITLE
Improve autocompletion behavior and fix LSP issues

### DIFF
--- a/src-tauri/src/commands/fuzzy.rs
+++ b/src-tauri/src/commands/fuzzy.rs
@@ -121,7 +121,7 @@ pub fn filter_completions(request: CompletionFilterRequest) -> Vec<FilteredCompl
       &request.context_word,
       CaseMatching::Smart,
       Normalization::Smart,
-      AtomKind::Fuzzy,
+      AtomKind::Substring,
       false,
    );
 

--- a/src/extensions/bundled/rust/extension.json
+++ b/src/extensions/bundled/rust/extension.json
@@ -21,10 +21,7 @@
   },
   "lsp": {
     "server": {
-      "default": "rust-analyzer",
-      "darwin": "./lsp/rust-analyzer-darwin",
-      "linux": "./lsp/rust-analyzer-linux",
-      "win32": "./lsp/rust-analyzer.exe"
+      "default": "rust-analyzer"
     },
     "args": [],
     "fileExtensions": [".rs"],

--- a/src/extensions/registry/extension-registry.ts
+++ b/src/extensions/registry/extension-registry.ts
@@ -6,6 +6,7 @@
 import { logger } from "@/features/editor/utils/logger";
 
 // Import bundled extension manifests
+import rustManifest from "../bundled/rust/extension.json";
 import typescriptManifest from "../bundled/typescript/extension.json";
 import type {
   BundledExtension,
@@ -59,7 +60,10 @@ class ExtensionRegistry {
    * Load all bundled extensions
    */
   private async loadBundledExtensions() {
-    const bundledManifests: ExtensionManifest[] = [typescriptManifest as ExtensionManifest];
+    const bundledManifests: ExtensionManifest[] = [
+      rustManifest as ExtensionManifest,
+      typescriptManifest as ExtensionManifest,
+    ];
 
     // Get absolute path to bundled extensions
     let basePath = "";

--- a/src/features/editor/config/constants.ts
+++ b/src/features/editor/config/constants.ts
@@ -64,6 +64,7 @@ export const EDITOR_CONSTANTS = {
   COMPLETION_CACHE_TTL_MS: 5000,
   MAX_COMPLETION_CACHE_SIZE: 100,
   MAX_POSITION_CACHE_SIZE: 50,
+  MAX_VISIBLE_COMPLETIONS: 5, // Max number of completions shown in dropdown
 
   // Hover Tooltip
   HOVER_TOOLTIP_DELAY: 300,

--- a/src/features/editor/stores/ui-store.ts
+++ b/src/features/editor/stores/ui-store.ts
@@ -32,6 +32,7 @@ interface EditorUIState {
   isHovering: boolean;
   isApplyingCompletion: boolean;
   aiCompletion: boolean;
+  lastInputTimestamp: number;
 
   // Search state
   searchQuery: string;
@@ -54,6 +55,7 @@ interface EditorUIActions {
   setIsHovering: (hovering: boolean) => void;
   setIsApplyingCompletion: (applying: boolean) => void;
   setAiCompletion: (enabled: boolean) => void;
+  setLastInputTimestamp: (timestamp: number) => void;
 
   // Search actions
   setSearchQuery: (query: string) => void;
@@ -77,6 +79,7 @@ export const useEditorUIStore = createSelectors(
     isHovering: false,
     isApplyingCompletion: false,
     aiCompletion: false,
+    lastInputTimestamp: 0,
 
     // Search state
     searchQuery: "",
@@ -96,6 +99,7 @@ export const useEditorUIStore = createSelectors(
       setIsHovering: (hovering) => set({ isHovering: hovering }),
       setIsApplyingCompletion: (applying) => set({ isApplyingCompletion: applying }),
       setAiCompletion: (enabled) => set({ aiCompletion: enabled }),
+      setLastInputTimestamp: (timestamp) => set({ lastInputTimestamp: timestamp }),
 
       // Search actions
       setSearchQuery: (query) => set({ searchQuery: query }),


### PR DESCRIPTION
## Summary
- Only trigger completions when user types (not on cursor movement/clicks)
- Change from fuzzy to substring matching for more predictable results
- Limit visible completions to 5 with scrollable list
- Add documentation panel next to completions (VS Code style)
- Fix dropdown positioning with zoom and scroll support
- Fix TypeScript LSP document sync and server routing
- Register Rust LSP in extension registry

## Test plan
- [ ] Type in a TypeScript file and verify completions appear
- [ ] Type in a Rust file and verify completions appear
- [ ] Click in editor without typing - completions should NOT appear
- [ ] Arrow keys should navigate through all completions (scrollable)
- [ ] Selected completion should show documentation panel on the right
- [ ] Zoom in/out and verify dropdown stays aligned with cursor