### PR TITLE
Add auto-refresh for externally created/deleted files

### DIFF
--- a/src/features/file-system/controllers/store.ts
+++ b/src/features/file-system/controllers/store.ts
@@ -869,25 +869,25 @@ export const useFileSystemStore = createSelectors(
       refreshDirectory: async (directoryPath: string) => {
         const dirNode = findFileInTree(get().files, directoryPath);
 
-        // If directory is not in the tree or not expanded, skip refresh
         if (!dirNode || !dirNode.isDir) {
           return;
         }
 
-        // Only refresh if the directory is expanded (visible in the tree)
-        if (!dirNode.expanded) {
+        // Check if directory is expanded using the file tree store
+        // Root folder is always considered expanded since it's always visible
+        const isRoot = directoryPath === get().rootFolderPath;
+        const isExpanded = isRoot || useFileTreeStore.getState().isExpanded(directoryPath);
+
+        if (!isExpanded) {
           return;
         }
 
-        // Read the directory contents
         const entries = await readDirectory(directoryPath);
 
         set((state) => {
-          // Update the directory contents while preserving all states
           const updated = updateDirectoryContents(state.files, directoryPath, entries as any[]);
 
           if (updated) {
-            // Successfully updated
             state.filesVersion++;
           }
         });


### PR DESCRIPTION
## Summary
- Auto-refresh file tree when files/directories are created or deleted externally
- Fix FileChangeEvent type to match Rust event types (`opened`/`reloaded`/`deleted`)
- Add debounced directory refresh (300ms) to batch rapid changes
- Fix `refreshDirectory` to properly check expanded state via file tree store
- Treat root folder as always expanded since it's always visible

## Test plan
- [ ] Open a project in the editor
- [ ] Create a new file externally (e.g., `touch newfile.txt` in terminal)
- [ ] Verify the file appears in the file tree within ~300ms
- [ ] Delete the file externally
- [ ] Verify the file disappears from the file tree
- [ ] Test with expanded subdirectories