### PR TITLE
Fix git blame not appearing after file switch

### DIFF
--- a/src/features/editor/components/layers/git-blame-layer.tsx
+++ b/src/features/editor/components/layers/git-blame-layer.tsx
@@ -40,14 +40,20 @@ const GitBlameLayerComponent = ({
   const lines = useMemo(() => splitLines(visualContent), [visualContent]);
   const currentLineContent = lines[visualCursorLine] || "";
 
+  // Reset width when file changes to prevent stale positioning during file switches
+  useLayoutEffect(() => {
+    setLineContentWidth(0);
+  }, [filePath]);
+
   // Measure the actual rendered width using a hidden element
   useLayoutEffect(() => {
     if (measureRef.current) {
       setLineContentWidth(measureRef.current.offsetWidth);
     }
-  }, [currentLineContent, fontSize, fontFamily, tabSize]);
+  }, [currentLineContent, fontSize, fontFamily, tabSize, filePath]);
 
-  if (!blameLine) return null;
+  // Calculate position only when we have valid data
+  const shouldShowBlame = blameLine && lineContentWidth > 0;
 
   // Calculate scroll ratio to compensate for browser rendering differences
   // (same approach as gutter component)
@@ -78,7 +84,7 @@ const GitBlameLayerComponent = ({
         lineHeight: `${lineHeight}px`,
       }}
     >
-      {/* Hidden element to measure actual text width */}
+      {/* Hidden element to measure actual text width - always rendered */}
       <span
         ref={measureRef}
         aria-hidden="true"
@@ -92,16 +98,18 @@ const GitBlameLayerComponent = ({
         {currentLineContent}
       </span>
 
-      <div
-        className="pointer-events-auto absolute flex items-center"
-        style={{
-          top: `${top}px`,
-          left: `${left}px`,
-          height: `${lineHeight}px`,
-        }}
-      >
-        <InlineGitBlame blameLine={blameLine} />
-      </div>
+      {shouldShowBlame && (
+        <div
+          className="pointer-events-auto absolute flex items-center"
+          style={{
+            top: `${top}px`,
+            left: `${left}px`,
+            height: `${lineHeight}px`,
+          }}
+        >
+          <InlineGitBlame blameLine={blameLine} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/version-control/git/controllers/use-blame.ts
+++ b/src/features/version-control/git/controllers/use-blame.ts
@@ -1,11 +1,15 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useFileSystemStore } from "@/features/file-system/controllers/store";
 import { useGitBlameStore } from "@/stores/git-blame-store";
+import type { GitBlameLine } from "../types/git";
 
 export function useGitBlame(filePath: string | undefined) {
   const rootFolderPath = useFileSystemStore((state) => state.rootFolderPath);
   const loadBlameForFile = useGitBlameStore((state) => state.loadBlameForFile);
-  const getBlameForLine = useGitBlameStore((state) => state.getBlameForLine);
+  // Subscribe to the actual blame data for this file so component re-renders when it loads
+  const blameData = useGitBlameStore((state) =>
+    filePath ? state.blameData.get(filePath) : undefined,
+  );
 
   useEffect(() => {
     if (filePath && rootFolderPath) {
@@ -13,10 +17,22 @@ export function useGitBlame(filePath: string | undefined) {
     }
   }, [filePath, rootFolderPath, loadBlameForFile]);
 
-  return {
-    getBlameForLine: (lineNumber: number) => {
-      if (!filePath) return null;
-      return getBlameForLine(filePath, lineNumber);
+  const getBlameForLine = useCallback(
+    (lineNumber: number): GitBlameLine | null => {
+      if (!filePath || !blameData) return null;
+
+      // Find the blame line that matches the line number
+      // Git blame line numbers are 1-based, editor line numbers are 0-based
+      const currentLine = lineNumber + 1;
+      const blameLine = blameData.lines.find((line) => {
+        const hunkStart = line.line_number;
+        const hunkEnd = line.line_number + line.total_lines - 1;
+        return currentLine >= hunkStart && currentLine <= hunkEnd;
+      });
+      return blameLine || null;
     },
-  };
+    [filePath, blameData],
+  );
+
+  return { getBlameForLine };
 }


### PR DESCRIPTION
## Summary
- Fix git blame overlay not appearing after switching files
- Fix horizontal positioning issues when switching between files with different line lengths

## Changes
- Reset `lineContentWidth` when file changes to prevent stale positioning
- Add `filePath` to measurement effect dependencies so it re-measures on file switch
- Subscribe to actual blame data in `useGitBlame` hook so component re-renders when async blame data loads

## Root Cause
1. **Positioning issue**: When switching files, `lineContentWidth` retained the old value causing incorrect horizontal positioning
2. **Missing blame**: The hook was subscribing to a store function (stable reference) instead of the actual blame data, so the component didn't re-render when blame data loaded asynchronously