### PR TITLE
Add new tree-sitter CDN and automatic extension reloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # dependency directories
 node_modules/
 
+examples/
+
 # Build output
 dist/
 
@@ -13,6 +15,7 @@ dist/
 
 # dotenv environment variables file
 .env
+.env.local
 
 # .vscode workspace settings file (keep extensions.json and settings.json for team consistency)
 .vscode/launch.json

--- a/src/extensions/languages/language-packager.ts
+++ b/src/extensions/languages/language-packager.ts
@@ -7,7 +7,8 @@ import type { ExtensionManifest } from "../types/extension-manifest";
 
 // CDN base URL for downloading WASM parsers and highlight queries
 // Can be configured via environment variable
-const CDN_BASE_URL = import.meta.env.VITE_PARSER_CDN_URL || "https://athas.dev/extensions";
+const CDN_BASE_URL =
+  import.meta.env.VITE_PARSER_CDN_URL || "https://tree-sitter-cdn-production.up.railway.app";
 
 // Old manifest format from JSON files
 interface LanguageManifestFile {

--- a/src/features/editor/extensions/manager.ts
+++ b/src/features/editor/extensions/manager.ts
@@ -378,6 +378,10 @@ class ExtensionManager {
       logger.error("Editor", `Error deactivating language extension ${extensionId}:`, error);
     }
 
+    // Clear in-memory parser to free memory
+    const { wasmParserLoader } = await import("../lib/wasm-parser/loader");
+    wasmParserLoader.unloadParser(extension.languageId);
+
     // Remove language providers
     this.languageProviders.delete(extension.languageId);
     for (const ext of extension.extensions) {


### PR DESCRIPTION
## Summary

- Update CDN URL for tree-sitter grammars to Railway-hosted endpoint (`tree-sitter-cdn-production.up.railway.app`)
- Automatically re-highlight open files when language extensions are installed
- Clear cached tokens and properly unload parsers from memory when extensions are uninstalled
- Add `examples/` and `.env.local` to gitignore

## Test plan

- [ ] Install a language extension and verify the currently open file gets re-highlighted automatically
- [ ] Uninstall a language extension and verify syntax highlighting is cleared for affected files
- [ ] Verify tree-sitter grammars load correctly from the new CDN