### PR TITLE
Add Cmd+hover definition link highlighting

### DIFF
--- a/src-tauri/src/lsp/client.rs
+++ b/src-tauri/src/lsp/client.rs
@@ -420,6 +420,13 @@ impl LspClient {
       self.request::<request::HoverRequest>(params).await
    }
 
+   pub async fn text_document_definition(
+      &self,
+      params: GotoDefinitionParams,
+   ) -> Result<Option<GotoDefinitionResponse>> {
+      self.request::<request::GotoDefinition>(params).await
+   }
+
    pub fn text_document_did_open(&self, params: DidOpenTextDocumentParams) -> Result<()> {
       self.notify::<notification::DidOpenTextDocument>(params)
    }

--- a/src-tauri/src/lsp/manager.rs
+++ b/src-tauri/src/lsp/manager.rs
@@ -449,6 +449,32 @@ impl LspManager {
       client.text_document_hover(params).await
    }
 
+   pub async fn get_definition(
+      &self,
+      file_path: &str,
+      line: u32,
+      character: u32,
+   ) -> Result<Option<GotoDefinitionResponse>> {
+      let client = self
+         .get_client_for_file(file_path)
+         .context("No LSP client for this file")?;
+
+      let text_document = TextDocumentIdentifier {
+         uri: Url::from_file_path(file_path).map_err(|_| anyhow::anyhow!("Invalid file path"))?,
+      };
+
+      let params = GotoDefinitionParams {
+         text_document_position_params: TextDocumentPositionParams {
+            text_document,
+            position: Position { line, character },
+         },
+         work_done_progress_params: Default::default(),
+         partial_result_params: Default::default(),
+      };
+
+      client.text_document_definition(params).await
+   }
+
    pub fn notify_document_open(&self, file_path: &str, content: String) -> Result<()> {
       let path = PathBuf::from(file_path);
       let _extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -402,6 +402,7 @@ fn main() {
          lsp_stop_for_file,
          lsp_get_completions,
          lsp_get_hover,
+         lsp_get_definition,
          lsp_document_open,
          lsp_document_change,
          lsp_document_close,

--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -27,6 +27,7 @@ import { calculateCursorPosition } from "../utils/position";
 import { scrollLogger } from "../utils/scroll-logger";
 import { InlineDiff } from "./diff/inline-diff";
 import { Gutter } from "./gutter/gutter";
+import { DefinitionLinkLayer } from "./layers/definition-link-layer";
 import { GitBlameLayer } from "./layers/git-blame-layer";
 import { HighlightLayer } from "./layers/highlight-layer";
 import { InputLayer } from "./layers/input-layer";
@@ -267,7 +268,9 @@ export function Editor({
     (e: React.MouseEvent<HTMLTextAreaElement>) => {
       if (!bufferId || !inputRef.current) return;
 
-      if (e.metaKey || e.ctrlKey) {
+      // Alt+click (Option+click on Mac) for multi-cursor (like VS Code)
+      // Cmd+click is reserved for go-to-definition
+      if (e.altKey) {
         e.preventDefault();
 
         const selectionStart = inputRef.current.selectionStart;
@@ -854,6 +857,14 @@ export function Editor({
             content={displayContent}
           />
         )}
+
+        <DefinitionLinkLayer
+          fontSize={fontSize}
+          fontFamily={fontFamily}
+          lineHeight={lineHeight}
+          content={displayContent}
+          textareaRef={inputRef}
+        />
 
         {filePath && (
           <GitBlameLayer

--- a/src/features/editor/components/layers/definition-link-layer.tsx
+++ b/src/features/editor/components/layers/definition-link-layer.tsx
@@ -1,0 +1,91 @@
+/**
+ * Definition Link Layer - Renders underline highlight for Cmd+hover symbols
+ */
+
+import type { RefObject } from "react";
+import { memo, useMemo } from "react";
+import { EDITOR_CONSTANTS } from "../../config/constants";
+import { useEditorUIStore } from "../../stores/ui-store";
+
+interface DefinitionLinkLayerProps {
+  fontSize: number;
+  fontFamily: string;
+  lineHeight: number;
+  content: string;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+}
+
+export const DefinitionLinkLayer = memo(
+  ({ fontSize, fontFamily, lineHeight, content, textareaRef }: DefinitionLinkLayerProps) => {
+    const definitionLinkRange = useEditorUIStore.use.definitionLinkRange();
+
+    const highlightStyle = useMemo(() => {
+      if (!definitionLinkRange) return null;
+
+      const lines = content.split("\n");
+      const { line, startColumn, endColumn } = definitionLinkRange;
+
+      if (line < 0 || line >= lines.length) return null;
+
+      const lineText = lines[line];
+      if (startColumn < 0 || endColumn > lineText.length) return null;
+
+      // Create a hidden element for measuring text width
+      const measureElement = document.createElement("span");
+      measureElement.style.cssText = `
+      position: absolute;
+      visibility: hidden;
+      white-space: pre;
+      font-family: ${fontFamily};
+      font-size: ${fontSize}px;
+    `;
+      document.body.appendChild(measureElement);
+
+      // Measure text before start column
+      const textBeforeStart = lineText.substring(0, startColumn);
+      measureElement.textContent = textBeforeStart;
+      const left =
+        measureElement.getBoundingClientRect().width + EDITOR_CONSTANTS.EDITOR_PADDING_LEFT;
+
+      // Measure the word itself
+      const wordText = lineText.substring(startColumn, endColumn);
+      measureElement.textContent = wordText;
+      const width = measureElement.getBoundingClientRect().width;
+
+      // Cleanup
+      document.body.removeChild(measureElement);
+
+      // Get current scroll position from textarea to position relative to viewport
+      const scrollTop = textareaRef.current?.scrollTop ?? 0;
+      const scrollLeft = textareaRef.current?.scrollLeft ?? 0;
+
+      const top = line * lineHeight + EDITOR_CONSTANTS.EDITOR_PADDING_TOP - scrollTop;
+
+      return {
+        top,
+        left: left - scrollLeft,
+        width: Math.max(width, 2),
+        height: lineHeight,
+      };
+    }, [definitionLinkRange, content, fontSize, fontFamily, lineHeight, textareaRef]);
+
+    if (!highlightStyle) return null;
+
+    return (
+      <div className="definition-link-layer pointer-events-none absolute inset-0 z-10">
+        <div
+          className="definition-link-highlight"
+          style={{
+            position: "absolute",
+            top: `${highlightStyle.top}px`,
+            left: `${highlightStyle.left}px`,
+            width: `${highlightStyle.width}px`,
+            height: `${highlightStyle.height}px`,
+            borderBottom: "1px solid var(--accent)",
+            cursor: "pointer",
+          }}
+        />
+      </div>
+    );
+  },
+);

--- a/src/features/editor/hooks/use-lsp-integration.ts
+++ b/src/features/editor/hooks/use-lsp-integration.ts
@@ -11,6 +11,7 @@ import { useEditorLayout } from "@/features/editor/hooks/use-layout";
 import { useSnippetCompletion } from "@/features/editor/hooks/use-snippet-completion";
 import { LspClient } from "@/features/editor/lsp/lsp-client";
 import { useLspStore } from "@/features/editor/lsp/lsp-store";
+import { useDefinitionLink } from "@/features/editor/lsp/use-definition-link";
 import { useGoToDefinition } from "@/features/editor/lsp/use-go-to-definition";
 import { useHover } from "@/features/editor/lsp/use-hover";
 import { useBufferStore } from "@/features/editor/stores/buffer-store";
@@ -104,9 +105,17 @@ export const useLspIntegration = ({
     isLanguageSupported: (fp) => isFileSupported(fp),
     filePath: filePath || "",
     fontSize,
-    lineNumbers,
-    gutterWidth,
     charWidth,
+  });
+
+  // Set up definition link highlighting (Cmd+hover)
+  const definitionLinkHandlers = useDefinitionLink({
+    filePath: filePath || "",
+    content: value,
+    fontSize,
+    charWidth,
+    isLanguageSupported: isLspSupported,
+    getDefinition: lspClient.getDefinition.bind(lspClient),
   });
 
   // Handle document lifecycle (open/close)
@@ -217,5 +226,6 @@ export const useLspIntegration = ({
     snippetCompletion,
     hoverHandlers,
     goToDefinitionHandlers,
+    definitionLinkHandlers,
   };
 };

--- a/src/features/editor/lsp/use-definition-link.ts
+++ b/src/features/editor/lsp/use-definition-link.ts
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useRef } from "react";
+import { EDITOR_CONSTANTS } from "@/features/editor/config/constants";
+import { useEditorUIStore } from "../stores/ui-store";
+
+interface Definition {
+  uri: string;
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+}
+
+interface UseDefinitionLinkProps {
+  filePath: string;
+  content: string;
+  fontSize: number;
+  charWidth: number;
+  isLanguageSupported: boolean;
+  getDefinition?: (
+    filePath: string,
+    line: number,
+    character: number,
+  ) => Promise<Definition[] | null>;
+}
+
+/**
+ * Find word boundaries at the given line and column
+ */
+function getWordBoundaries(
+  content: string,
+  line: number,
+  column: number,
+): { startColumn: number; endColumn: number } | null {
+  const lines = content.split("\n");
+  if (line < 0 || line >= lines.length) return null;
+
+  const lineText = lines[line];
+  if (column < 0 || column >= lineText.length) return null;
+
+  // Word characters: letters, digits, underscore
+  const wordRegex = /[\w]/;
+
+  // Check if cursor is on a word character
+  if (!wordRegex.test(lineText[column])) return null;
+
+  // Find start of word
+  let startColumn = column;
+  while (startColumn > 0 && wordRegex.test(lineText[startColumn - 1])) {
+    startColumn--;
+  }
+
+  // Find end of word
+  let endColumn = column;
+  while (endColumn < lineText.length && wordRegex.test(lineText[endColumn])) {
+    endColumn++;
+  }
+
+  return { startColumn, endColumn };
+}
+
+export const useDefinitionLink = ({
+  filePath,
+  content,
+  fontSize,
+  charWidth,
+  isLanguageSupported,
+  getDefinition,
+}: UseDefinitionLinkProps) => {
+  const { actions } = useEditorUIStore();
+  const isModifierHeldRef = useRef(false);
+  const lastMousePosRef = useRef<{ x: number; y: number } | null>(null);
+  const editorRefCache = useRef<HTMLElement | null>(null);
+
+  // Track the current word being hovered (separate from pending request)
+  const currentWordRef = useRef<{
+    line: number;
+    startColumn: number;
+    endColumn: number;
+  } | null>(null);
+  // Track pending LSP request to cancel/ignore stale results
+  const pendingRequestRef = useRef<{ cancelled: boolean } | null>(null);
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Calculate position from mouse coordinates
+  const calculatePosition = useCallback(
+    (x: number, y: number, editor: HTMLElement): { line: number; column: number } | null => {
+      const rect = editor.getBoundingClientRect();
+      const relX = x - rect.left;
+      const relY = y - rect.top;
+
+      // Get scroll from textarea (the actual scrollable element)
+      const textarea = editor.querySelector("textarea");
+      const scrollTop = textarea?.scrollTop ?? 0;
+      const scrollLeft = textarea?.scrollLeft ?? 0;
+
+      const lineHeight = Math.ceil(fontSize * EDITOR_CONSTANTS.LINE_HEIGHT_MULTIPLIER);
+      // Always use EDITOR_PADDING_LEFT since mouse events are captured on the
+      // overlay-editor-container which is positioned AFTER the gutter
+      const contentOffsetX = EDITOR_CONSTANTS.EDITOR_PADDING_LEFT;
+      const paddingTop = EDITOR_CONSTANTS.EDITOR_PADDING_TOP;
+
+      const line = Math.floor((relY - paddingTop + scrollTop) / lineHeight);
+      const column = Math.floor((relX - contentOffsetX + scrollLeft) / charWidth);
+
+      if (line < 0 || column < 0) return null;
+
+      return { line, column };
+    },
+    [fontSize, charWidth],
+  );
+
+  // Update the definition link based on current mouse position
+  // Makes async LSP call to validate the symbol has a definition
+  const updateDefinitionLink = useCallback(
+    (x: number, y: number, editor: HTMLElement) => {
+      if (!isLanguageSupported || !filePath || !getDefinition) {
+        currentWordRef.current = null;
+        actions.setDefinitionLinkRange(null);
+        return;
+      }
+
+      const pos = calculatePosition(x, y, editor);
+      if (!pos) {
+        currentWordRef.current = null;
+        actions.setDefinitionLinkRange(null);
+        return;
+      }
+
+      const boundaries = getWordBoundaries(content, pos.line, pos.column);
+      if (!boundaries) {
+        currentWordRef.current = null;
+        actions.setDefinitionLinkRange(null);
+        return;
+      }
+
+      // Check if we're still hovering the same word
+      const currentWord = currentWordRef.current;
+      if (
+        currentWord &&
+        currentWord.line === pos.line &&
+        currentWord.startColumn === boundaries.startColumn &&
+        currentWord.endColumn === boundaries.endColumn
+      ) {
+        return;
+      }
+
+      // Different word - update tracking and reset everything
+      currentWordRef.current = {
+        line: pos.line,
+        startColumn: boundaries.startColumn,
+        endColumn: boundaries.endColumn,
+      };
+
+      // Cancel any pending request
+      if (pendingRequestRef.current) {
+        pendingRequestRef.current.cancelled = true;
+        pendingRequestRef.current = null;
+      }
+
+      // Clear existing debounce timer
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+
+      // Clear highlight while we query the new word
+      actions.setDefinitionLinkRange(null);
+
+      // Make LSP call immediately (same word check prevents spamming)
+      const request = { cancelled: false };
+      pendingRequestRef.current = request;
+
+      getDefinition(filePath, pos.line, pos.column)
+        .then((definitions) => {
+          if (request.cancelled) return;
+
+          if (definitions && definitions.length > 0) {
+            actions.setDefinitionLinkRange({
+              line: pos.line,
+              startColumn: boundaries.startColumn,
+              endColumn: boundaries.endColumn,
+            });
+          } else {
+            actions.setDefinitionLinkRange(null);
+          }
+        })
+        .catch(() => {
+          if (!request.cancelled) {
+            actions.setDefinitionLinkRange(null);
+          }
+        });
+    },
+    [content, filePath, isLanguageSupported, getDefinition, calculatePosition, actions],
+  );
+
+  // Handle mouse move - track position and update highlight if modifier held
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      editorRefCache.current = e.currentTarget;
+      lastMousePosRef.current = { x: e.clientX, y: e.clientY };
+
+      if (isModifierHeldRef.current) {
+        updateDefinitionLink(e.clientX, e.clientY, e.currentTarget);
+      }
+    },
+    [updateDefinitionLink],
+  );
+
+  // Handle mouse leave - clear highlight
+  const handleMouseLeave = useCallback(() => {
+    lastMousePosRef.current = null;
+    currentWordRef.current = null;
+
+    // Cancel pending requests
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    if (pendingRequestRef.current) {
+      pendingRequestRef.current.cancelled = true;
+      pendingRequestRef.current = null;
+    }
+
+    actions.setDefinitionLinkRange(null);
+  }, [actions]);
+
+  // Global key event handlers
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey) {
+        if (!isModifierHeldRef.current) {
+          isModifierHeldRef.current = true;
+          // Update highlight with current mouse position
+          if (lastMousePosRef.current && editorRefCache.current) {
+            updateDefinitionLink(
+              lastMousePosRef.current.x,
+              lastMousePosRef.current.y,
+              editorRefCache.current,
+            );
+          }
+        }
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      // Clear when modifier is released
+      if (!e.metaKey && !e.ctrlKey) {
+        isModifierHeldRef.current = false;
+        currentWordRef.current = null;
+
+        // Cancel pending requests
+        if (debounceTimerRef.current) {
+          clearTimeout(debounceTimerRef.current);
+          debounceTimerRef.current = null;
+        }
+        if (pendingRequestRef.current) {
+          pendingRequestRef.current.cancelled = true;
+          pendingRequestRef.current = null;
+        }
+
+        actions.setDefinitionLinkRange(null);
+      }
+    };
+
+    // Also handle blur to clear state when window loses focus
+    const handleBlur = () => {
+      isModifierHeldRef.current = false;
+      currentWordRef.current = null;
+
+      // Cancel pending requests
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      if (pendingRequestRef.current) {
+        pendingRequestRef.current.cancelled = true;
+        pendingRequestRef.current = null;
+      }
+
+      actions.setDefinitionLinkRange(null);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    window.addEventListener("blur", handleBlur);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+      window.removeEventListener("blur", handleBlur);
+
+      // Cleanup timers on unmount
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [updateDefinitionLink, actions]);
+
+  return {
+    handleMouseMove,
+    handleMouseLeave,
+  };
+};

--- a/src/features/editor/lsp/use-go-to-definition.ts
+++ b/src/features/editor/lsp/use-go-to-definition.ts
@@ -22,8 +22,6 @@ interface UseGoToDefinitionProps {
   isLanguageSupported?: (filePath: string) => boolean;
   filePath: string;
   fontSize: number;
-  lineNumbers: boolean;
-  gutterWidth: number;
   charWidth: number;
 }
 
@@ -32,8 +30,6 @@ export const useGoToDefinition = ({
   isLanguageSupported,
   filePath,
   fontSize,
-  lineNumbers,
-  gutterWidth,
   charWidth,
 }: UseGoToDefinitionProps) => {
   const handleClick = useCallback(
@@ -56,14 +52,19 @@ export const useGoToDefinition = ({
       const x = e.clientX - rect.left;
       const y = e.clientY - rect.top;
 
+      // Get scroll from textarea (the actual scrollable element)
+      const textarea = editor.querySelector("textarea");
+      const scrollTop = textarea?.scrollTop ?? 0;
+      const scrollLeft = textarea?.scrollLeft ?? 0;
+
       const lineHeight = Math.ceil(fontSize * EDITOR_CONSTANTS.LINE_HEIGHT_MULTIPLIER);
-      const contentOffsetX = lineNumbers
-        ? gutterWidth + EDITOR_CONSTANTS.GUTTER_MARGIN
-        : EDITOR_CONSTANTS.EDITOR_PADDING_LEFT;
+      // Always use EDITOR_PADDING_LEFT since mouse events are captured on the
+      // overlay-editor-container which is positioned AFTER the gutter
+      const contentOffsetX = EDITOR_CONSTANTS.EDITOR_PADDING_LEFT;
       const paddingTop = EDITOR_CONSTANTS.EDITOR_PADDING_TOP;
 
-      const line = Math.floor((y - paddingTop + editor.scrollTop) / lineHeight);
-      const character = Math.floor((x - contentOffsetX + editor.scrollLeft) / charWidth);
+      const line = Math.floor((y - paddingTop + scrollTop) / lineHeight);
+      const character = Math.floor((x - contentOffsetX + scrollLeft) / charWidth);
 
       if (line >= 0 && character >= 0) {
         try {
@@ -114,7 +115,7 @@ export const useGoToDefinition = ({
         }
       }
     },
-    [getDefinition, isLanguageSupported, filePath, fontSize, lineNumbers, gutterWidth, charWidth],
+    [getDefinition, isLanguageSupported, filePath, fontSize, charWidth],
   );
 
   return {

--- a/src/features/editor/stores/ui-store.ts
+++ b/src/features/editor/stores/ui-store.ts
@@ -20,6 +20,12 @@ type SearchMatch = {
   end: number;
 };
 
+type DefinitionLinkRange = {
+  line: number;
+  startColumn: number;
+  endColumn: number;
+};
+
 interface EditorUIState {
   // Completion state
   lspCompletions: CompletionItem[];
@@ -38,6 +44,9 @@ interface EditorUIState {
   searchQuery: string;
   searchMatches: SearchMatch[];
   currentMatchIndex: number;
+
+  // Definition link state (for Cmd+hover highlighting)
+  definitionLinkRange: DefinitionLinkRange | null;
 
   // Actions
   actions: EditorUIActions;
@@ -64,6 +73,9 @@ interface EditorUIActions {
   clearSearch: () => void;
   searchNext: () => void;
   searchPrevious: () => void;
+
+  // Definition link actions
+  setDefinitionLinkRange: (range: DefinitionLinkRange | null) => void;
 }
 
 export const useEditorUIStore = createSelectors(
@@ -85,6 +97,9 @@ export const useEditorUIStore = createSelectors(
     searchQuery: "",
     searchMatches: [],
     currentMatchIndex: -1,
+
+    // Definition link state
+    definitionLinkRange: null,
 
     // Actions
     actions: {
@@ -126,6 +141,9 @@ export const useEditorUIStore = createSelectors(
           set({ currentMatchIndex: prevIndex });
         }
       },
+
+      // Definition link actions
+      setDefinitionLinkRange: (range) => set({ definitionLinkRange: range }),
     },
   })),
 );


### PR DESCRIPTION
## Summary
- Add visual underline highlighting when Cmd+hovering over symbols with LSP definitions
- Backend: Add `lsp_get_definition` Tauri command
- Frontend: New `useDefinitionLink` hook and `DefinitionLinkLayer` component

## Test plan
- Hold Cmd and hover over a symbol in a TypeScript file
- Verify underline appears only for symbols with LSP definitions
- Click to navigate to definition