### PR TITLE
Fix mention selection to respect filtered file count

### DIFF
--- a/src/components/ai-chat/ai-chat-input-bar.tsx
+++ b/src/components/ai-chat/ai-chat-input-bar.tsx
@@ -156,7 +156,8 @@ const AIChatInputBar = memo(function AIChatInputBar({
     if (mentionState.active) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        selectNext();
+        const filteredFiles = getFilteredFiles(allProjectFiles);
+        selectNext(filteredFiles.length);
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         selectPrevious();

--- a/src/stores/ai-chat/store.ts
+++ b/src/stores/ai-chat/store.ts
@@ -412,9 +412,10 @@ export const useAIChatStore = create<AIChatState & AIChatActions>()(
             state.mentionState.position = position;
           }),
 
-        selectNext: () =>
+        selectNext: (totalItems: number) =>
           set((state) => {
-            state.mentionState.selectedIndex = Math.min(state.mentionState.selectedIndex + 1, 4);
+            const maxIndex = Math.max(totalItems - 1, 0);
+            state.mentionState.selectedIndex = Math.min(state.mentionState.selectedIndex + 1, maxIndex);
           }),
 
         selectPrevious: () =>

--- a/src/stores/ai-chat/types.ts
+++ b/src/stores/ai-chat/types.ts
@@ -74,7 +74,7 @@ export interface AIChatActions {
   hideMention: () => void;
   updateSearch: (search: string) => void;
   updatePosition: (position: { top: number; left: number }) => void;
-  selectNext: () => void;
+  selectNext: (totalItems: number) => void;
   selectPrevious: () => void;
   setSelectedIndex: (index: number) => void;
   getFilteredFiles: (allFiles: FileEntry[]) => FileEntry[];


### PR DESCRIPTION
# Pull Request

## Description

Fixed a bug in the AI chat mention selection where the `selectNext` function was hardcoded to allow a maximum of 5 items (index 0-4), regardless of the actual number of filtered files available. This caused incorrect behavior when selecting through mentions with fewer items.

### Changes Made

- Updated `selectNext` action to accept `totalItems` parameter instead of using hardcoded limit of 4
- Modified the selection logic to calculate `maxIndex` based on the actual number of filtered files
- Updated the type signature in `AIChatActions` interface to reflect the new parameter
- Updated the call site in `ai-chat-input-bar.tsx` to pass the filtered files count when invoking `selectNext`

## Related Issues

Closes #

## Checklist

- [x] I have read and will follow the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read and agree to the [Contributor License and Feedback Agreement](../CONTRIBUTOR_LICENSE_AND_FEEDBACK_AGREEMENT.md).

https://claude.ai/code/session_01PwR8J37gjzpQ1tEbEJUgTi