### PR TITLE
Chore: prune deprecated AI models

### DIFF
--- a/src/features/ai/types/providers.ts
+++ b/src/features/ai/types/providers.ts
@@ -166,11 +166,6 @@ export const AI_PROVIDERS: ModelProvider[] = [
         name: "o1",
         maxTokens: 200000,
       },
-      {
-        id: "o1-mini",
-        name: "o1 Mini",
-        maxTokens: 128000,
-      },
     ],
   },
   {
@@ -220,16 +215,6 @@ export const AI_PROVIDERS: ModelProvider[] = [
         maxTokens: 1048576,
       },
       {
-        id: "google/gemini-2.5-pro",
-        name: "Gemini 2.5 Pro",
-        maxTokens: 1048576,
-      },
-      {
-        id: "google/gemini-2.5-flash",
-        name: "Gemini 2.5 Flash",
-        maxTokens: 1048576,
-      },
-      {
         id: "deepseek/deepseek-v3.2",
         name: "DeepSeek V3.2",
         maxTokens: 163840,
@@ -260,21 +245,6 @@ export const AI_PROVIDERS: ModelProvider[] = [
       {
         id: "gemini-3-flash-preview",
         name: "Gemini 3 Flash Preview",
-        maxTokens: 1048576,
-      },
-      {
-        id: "gemini-2.5-pro",
-        name: "Gemini 2.5 Pro",
-        maxTokens: 1048576,
-      },
-      {
-        id: "gemini-2.5-flash",
-        name: "Gemini 2.5 Flash",
-        maxTokens: 1048576,
-      },
-      {
-        id: "gemini-2.5-flash-lite",
-        name: "Gemini 2.5 Flash Lite",
         maxTokens: 1048576,
       },
     ],

--- a/src/features/editor/hooks/use-inline-edit.ts
+++ b/src/features/editor/hooks/use-inline-edit.ts
@@ -16,7 +16,7 @@ const DEFAULT_INLINE_EDIT_MODELS: AutocompleteModel[] = [
   { id: "mistralai/devstral-small", name: "Devstral Small 1.1" },
   { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5" },
   { id: "openai/gpt-5-nano", name: "GPT-5 Nano" },
-  { id: "google/gemini-2.5-flash-lite", name: "Gemini 2.5 Flash Lite" },
+  { id: "google/gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
 ];
 const INLINE_EDIT_POPOVER_WIDTH = 320;
 const INLINE_EDIT_POPOVER_ESTIMATED_HEIGHT = 170;

--- a/src/features/layout/components/footer/editor-footer.tsx
+++ b/src/features/layout/components/footer/editor-footer.tsx
@@ -41,7 +41,7 @@ const DEFAULT_AUTOCOMPLETE_MODELS: AutocompleteModel[] = [
   { id: "mistralai/devstral-small", name: "Devstral Small 1.1" },
   { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5" },
   { id: "openai/gpt-5-nano", name: "GPT-5 Nano" },
-  { id: "google/gemini-2.5-flash-lite", name: "Gemini 2.5 Flash Lite" },
+  { id: "google/gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
 ];
 
 // LSP Status Indicator Component

--- a/src/features/settings/components/tabs/ai-settings.tsx
+++ b/src/features/settings/components/tabs/ai-settings.tsx
@@ -23,7 +23,7 @@ const DEFAULT_AUTOCOMPLETE_MODELS = [
   { id: "mistralai/devstral-small", name: "Devstral Small 1.1" },
   { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5" },
   { id: "openai/gpt-5-nano", name: "GPT-5 Nano" },
-  { id: "google/gemini-2.5-flash-lite", name: "Gemini 2.5 Flash Lite" },
+  { id: "google/gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
 ];
 
 function resolveAutocompleteDefaultModelId(models: Array<{ id: string; name: string }>): string {

--- a/src/features/settings/store.ts
+++ b/src/features/settings/store.ts
@@ -4,6 +4,7 @@ import { load, type Store } from "@tauri-apps/plugin-store";
 import { create } from "zustand";
 import { combine } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
+import { getProviderById } from "@/features/ai/types/providers";
 import { settingsSearchIndex } from "./config/search-index";
 import { cacheFontsForBootstrap, cacheThemeForBootstrap } from "./lib/appearance-bootstrap";
 import { normalizeUiFontSize, UI_FONT_SIZE_DEFAULT } from "./lib/ui-font-size";
@@ -11,6 +12,36 @@ import type { CoreFeaturesState } from "./types/feature";
 import type { SearchResult, SearchState } from "./types/search";
 
 type Theme = string;
+
+const DEFAULT_AI_PROVIDER_ID = "anthropic";
+const DEFAULT_AI_MODEL_ID = "claude-sonnet-4-6";
+const DEFAULT_AI_AUTOCOMPLETE_MODEL_ID = "mistralai/devstral-small";
+
+const AI_MODEL_MIGRATIONS: Record<string, Record<string, string>> = {
+  anthropic: {
+    "claude-sonnet-4-5": "claude-sonnet-4-6",
+  },
+  gemini: {
+    "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+    "gemini-2.5-pro": "gemini-3.1-pro-preview",
+    "gemini-2.5-flash": "gemini-3-flash-preview",
+    "gemini-2.5-flash-lite": "gemini-3-flash-preview",
+    "gemini-2.0-flash": "gemini-3-flash-preview",
+  },
+  openai: {
+    "o1-mini": "o3-mini",
+  },
+  openrouter: {
+    "anthropic/claude-sonnet-4.5": "anthropic/claude-sonnet-4.6",
+    "google/gemini-3-pro-preview": "google/gemini-3.1-pro-preview",
+    "google/gemini-2.5-pro": "google/gemini-3.1-pro-preview",
+    "google/gemini-2.5-flash": "google/gemini-3-flash-preview",
+  },
+};
+
+const AI_AUTOCOMPLETE_MODEL_MIGRATIONS: Record<string, string> = {
+  "google/gemini-2.5-flash-lite": "google/gemini-3-flash-preview",
+};
 
 interface Settings {
   // General
@@ -88,6 +119,43 @@ interface Settings {
   gitChangesFolderView: boolean;
 }
 
+const normalizeAISettings = (settings: Settings): Settings => {
+  const normalizedSettings = { ...settings };
+  const provider =
+    getProviderById(normalizedSettings.aiProviderId) || getProviderById(DEFAULT_AI_PROVIDER_ID);
+
+  if (!provider) {
+    return {
+      ...normalizedSettings,
+      aiProviderId: DEFAULT_AI_PROVIDER_ID,
+      aiModelId: DEFAULT_AI_MODEL_ID,
+      aiAutocompleteModelId:
+        AI_AUTOCOMPLETE_MODEL_MIGRATIONS[normalizedSettings.aiAutocompleteModelId] ||
+        normalizedSettings.aiAutocompleteModelId ||
+        DEFAULT_AI_AUTOCOMPLETE_MODEL_ID,
+    };
+  }
+
+  normalizedSettings.aiProviderId = provider.id;
+  normalizedSettings.aiModelId =
+    AI_MODEL_MIGRATIONS[provider.id]?.[normalizedSettings.aiModelId] ||
+    normalizedSettings.aiModelId;
+
+  if (
+    provider.models.length > 0 &&
+    !provider.models.some((model) => model.id === normalizedSettings.aiModelId)
+  ) {
+    normalizedSettings.aiModelId = provider.models[0].id;
+  }
+
+  normalizedSettings.aiAutocompleteModelId =
+    AI_AUTOCOMPLETE_MODEL_MIGRATIONS[normalizedSettings.aiAutocompleteModelId] ||
+    normalizedSettings.aiAutocompleteModelId ||
+    DEFAULT_AI_AUTOCOMPLETE_MODEL_ID;
+
+  return normalizedSettings;
+};
+
 const defaultSettings: Settings = {
   // General
   autoSave: true,
@@ -118,12 +186,12 @@ const defaultSettings: Settings = {
   nativeMenuBar: false,
   compactMenuBar: true,
   // AI
-  aiProviderId: "anthropic",
-  aiModelId: "claude-sonnet-4-6",
+  aiProviderId: DEFAULT_AI_PROVIDER_ID,
+  aiModelId: DEFAULT_AI_MODEL_ID,
   aiChatWidth: 400,
   isAIChatVisible: false,
   aiCompletion: true,
-  aiAutocompleteModelId: "mistralai/devstral-small",
+  aiAutocompleteModelId: DEFAULT_AI_AUTOCOMPLETE_MODEL_ID,
   aiDefaultSessionMode: "",
   ollamaBaseUrl: "http://localhost:11434",
   // Layout
@@ -313,27 +381,28 @@ const initializeSettings = async () => {
       loadedSettings.theme = detectedTheme;
     }
 
-    loadedSettings.uiFontSize = normalizeUiFontSize(loadedSettings.uiFontSize);
+    const normalizedSettings = normalizeAISettings(loadedSettings);
+    normalizedSettings.uiFontSize = normalizeUiFontSize(normalizedSettings.uiFontSize);
 
-    applyTheme(loadedSettings.theme);
+    applyTheme(normalizedSettings.theme);
     cacheFontsForBootstrap(
-      loadedSettings.fontFamily,
-      loadedSettings.uiFontFamily,
-      loadedSettings.uiFontSize,
+      normalizedSettings.fontFamily,
+      normalizedSettings.uiFontFamily,
+      normalizedSettings.uiFontSize,
     );
 
     // Sync Ollama base URL with provider
-    if (loadedSettings.ollamaBaseUrl) {
+    if (normalizedSettings.ollamaBaseUrl) {
       import("@/utils/providers").then(({ setOllamaBaseUrl }) => {
-        setOllamaBaseUrl(loadedSettings.ollamaBaseUrl);
+        setOllamaBaseUrl(normalizedSettings.ollamaBaseUrl);
       });
     }
 
     // Update Zustand store
-    useSettingsStore.getState().initializeSettings(loadedSettings);
-    await saveSettingsToStore(loadedSettings);
+    useSettingsStore.getState().initializeSettings(normalizedSettings);
+    await saveSettingsToStore(normalizedSettings);
 
-    return loadedSettings;
+    return normalizedSettings;
   } catch (error) {
     console.error("Failed to initialize settings:", error);
     return defaultSettings;
@@ -360,7 +429,10 @@ export const useSettingsStore = create(
         updateSettingsFromJSON: (jsonString: string): boolean => {
           try {
             const parsedSettings = JSON.parse(jsonString);
-            const validatedSettings = { ...defaultSettings, ...parsedSettings };
+            const validatedSettings = normalizeAISettings({
+              ...defaultSettings,
+              ...parsedSettings,
+            });
 
             set((state) => {
               state.settings = validatedSettings;


### PR DESCRIPTION
## Summary
- remove deprecated Gemini and OpenAI model entries from the hardcoded AI picker
- update Anthropic defaults from Claude Sonnet 4.5 to Claude Sonnet 4.6
- migrate saved deprecated model selections to valid replacements so existing users do not break
- refresh fallback autocomplete model defaults to a current Gemini option

## Validation
- checked current model/deprecation status against official provider docs on March 10, 2026
- bun fix
- bun typecheck
- bun test
