### PR TITLE
Improve split pane behavior and UI polish

### DIFF
--- a/src-tauri/src/commands/ui/window.rs
+++ b/src-tauri/src/commands/ui/window.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU32, Ordering};
-use tauri::{
-   AppHandle, Manager, TitleBarStyle, WebviewBuilder, WebviewUrl, WebviewWindow, command,
-};
+use tauri::{AppHandle, Manager, WebviewBuilder, WebviewUrl, WebviewWindow, command};
 
 // Counter for generating unique web viewer labels
 static WEB_VIEWER_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -87,16 +85,22 @@ pub fn create_app_window_internal(
    );
    let url = build_window_open_url(request.as_ref());
 
-   let window = tauri::WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
-      .title("")
-      .inner_size(1200.0, 800.0)
-      .min_inner_size(400.0, 400.0)
-      .center()
+   let window_builder =
+      tauri::WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
+         .title("")
+         .inner_size(1200.0, 800.0)
+         .min_inner_size(400.0, 400.0)
+         .center()
       .decorations(true)
       .resizable(true)
-      .shadow(true)
+      .shadow(true);
+
+   #[cfg(target_os = "macos")]
+   let window_builder = window_builder
       .hidden_title(true)
-      .title_bar_style(TitleBarStyle::Overlay)
+      .title_bar_style(tauri::TitleBarStyle::Overlay);
+
+   let window = window_builder
       .build()
       .map_err(|e| format!("Failed to create app window: {e}"))?;
 

--- a/src-tauri/src/commands/ui/window.rs
+++ b/src-tauri/src/commands/ui/window.rs
@@ -85,12 +85,11 @@ pub fn create_app_window_internal(
    );
    let url = build_window_open_url(request.as_ref());
 
-   let window_builder =
-      tauri::WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
-         .title("")
-         .inner_size(1200.0, 800.0)
-         .min_inner_size(400.0, 400.0)
-         .center()
+   let window_builder = tauri::WebviewWindowBuilder::new(app, &label, WebviewUrl::App(url.into()))
+      .title("")
+      .inner_size(1200.0, 800.0)
+      .min_inner_size(400.0, 400.0)
+      .center()
       .decorations(true)
       .resizable(true)
       .shadow(true);

--- a/src/features/panes/components/pane-container.tsx
+++ b/src/features/panes/components/pane-container.tsx
@@ -803,20 +803,22 @@ export function PaneContainer({ pane }: PaneContainerProps) {
     <div
       ref={containerRef}
       data-pane-container
-      className={`relative flex h-full w-full flex-col overflow-hidden bg-primary-bg ${
-        isActivePane ? "ring-1 ring-accent/30" : ""
-      } ${isDragOver ? "ring-2 ring-accent" : ""}`}
+      data-pane-id={pane.id}
+      className={`@container relative flex h-full w-full flex-col overflow-hidden bg-primary-bg transition-all duration-200 ${
+        isActivePane ? "ring-1 ring-border/40 ring-inset z-10" : "z-0"
+      } ${isDragOver ? "ring-2 ring-accent ring-inset z-20" : ""}`}
       onClick={handlePaneClick}
       onMouseUp={handleMouseUp}
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
+<<<<<<< HEAD
       {isDragOver && !isTabDragOver && (
         <div className="pointer-events-none absolute inset-0 z-40 bg-accent/10" />
       )}
       <SplitDropOverlay visible={isTabDragOver} onDrop={handleSplitDrop} />
-      {paneBuffers.length > 0 && <TabBar paneId={pane.id} onTabClick={handleTabClick} />}
+      <TabBar paneId={pane.id} onTabClick={handleTabClick} isActivePane={isActivePane} />
       <div className="relative min-h-0 flex-1 overflow-hidden">
         {(!activeBuffer || activeBuffer.type === "newTab") && !shouldRenderCarousel && (
           <EmptyEditorState />

--- a/src/features/panes/components/pane-container.tsx
+++ b/src/features/panes/components/pane-container.tsx
@@ -813,7 +813,6 @@ export function PaneContainer({ pane }: PaneContainerProps) {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-<<<<<<< HEAD
       {isDragOver && !isTabDragOver && (
         <div className="pointer-events-none absolute inset-0 z-40 bg-accent/10" />
       )}

--- a/src/features/panes/components/pane-resize-handle.tsx
+++ b/src/features/panes/components/pane-resize-handle.tsx
@@ -4,14 +4,21 @@ import { MIN_PANE_SIZE } from "../constants/pane";
 interface PaneResizeHandleProps {
   direction: "horizontal" | "vertical";
   onResize: (sizes: [number, number]) => void;
+  onResizeEnd?: (sizes: [number, number]) => void;
   initialSizes: [number, number];
 }
 
-export function PaneResizeHandle({ direction, onResize, initialSizes }: PaneResizeHandleProps) {
+export function PaneResizeHandle({
+  direction,
+  onResize,
+  onResizeEnd,
+  initialSizes,
+}: PaneResizeHandleProps) {
   const [isDragging, setIsDragging] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const startPositionRef = useRef(0);
   const startSizesRef = useRef(initialSizes);
+  const currentSizesRef = useRef(initialSizes);
 
   const isHorizontal = direction === "horizontal";
 
@@ -21,15 +28,10 @@ export function PaneResizeHandle({ direction, onResize, initialSizes }: PaneResi
       setIsDragging(true);
       startPositionRef.current = isHorizontal ? e.clientX : e.clientY;
       startSizesRef.current = initialSizes;
+      currentSizesRef.current = initialSizes;
     },
     [isHorizontal, initialSizes],
   );
-
-  const handleDoubleClick = useCallback(() => {
-    const pairTotal = initialSizes[0] + initialSizes[1];
-    const evenSize = pairTotal / 2;
-    onResize([evenSize, evenSize]);
-  }, [initialSizes, onResize]);
 
   useEffect(() => {
     if (!isDragging) return;
@@ -43,6 +45,7 @@ export function PaneResizeHandle({ direction, onResize, initialSizes }: PaneResi
       const handleSize = isHorizontal ? handle.offsetWidth : handle.offsetHeight;
       const containerSize =
         (isHorizontal ? containerRect.width : containerRect.height) - handleSize;
+      if (containerSize <= 0) return;
 
       const currentPosition = isHorizontal ? e.clientX : e.clientY;
       const delta = currentPosition - startPositionRef.current;
@@ -52,22 +55,16 @@ export function PaneResizeHandle({ direction, onResize, initialSizes }: PaneResi
       const scaledDelta = (delta / containerSize) * pairTotal;
 
       let newFirstSize = startSizesRef.current[0] + scaledDelta;
-      let newSecondSize = startSizesRef.current[1] - scaledDelta;
+      newFirstSize = Math.max(0, Math.min(pairTotal, newFirstSize));
+      const nextSizes: [number, number] = [newFirstSize, pairTotal - newFirstSize];
 
-      const minSize = Math.min(MIN_PANE_SIZE, pairTotal * 0.1);
-      if (newFirstSize < minSize) {
-        newFirstSize = minSize;
-        newSecondSize = pairTotal - minSize;
-      } else if (newSecondSize < minSize) {
-        newSecondSize = minSize;
-        newFirstSize = pairTotal - minSize;
-      }
-
-      onResize([newFirstSize, newSecondSize]);
+      currentSizesRef.current = nextSizes;
+      onResize(nextSizes);
     };
 
     const handleMouseUp = () => {
       setIsDragging(false);
+      onResizeEnd?.(currentSizesRef.current);
     };
 
     document.addEventListener("mousemove", handleMouseMove);
@@ -77,7 +74,7 @@ export function PaneResizeHandle({ direction, onResize, initialSizes }: PaneResi
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [isDragging, isHorizontal, onResize]);
+  }, [isDragging, isHorizontal, onResize, onResizeEnd]);
 
   return (
     <div
@@ -93,7 +90,6 @@ export function PaneResizeHandle({ direction, onResize, initialSizes }: PaneResi
       aria-valuemin={MIN_PANE_SIZE}
       aria-valuemax={100 - MIN_PANE_SIZE}
       tabIndex={0}
-      onDoubleClick={handleDoubleClick}
     >
       <div
         className={`bg-border transition-colors ${

--- a/src/features/panes/components/pane-resize-handle.tsx
+++ b/src/features/panes/components/pane-resize-handle.tsx
@@ -80,7 +80,7 @@ export function PaneResizeHandle({
     <div
       ref={containerRef}
       className={`group relative flex shrink-0 items-center justify-center ${
-        isHorizontal ? "h-full w-1 cursor-col-resize" : "h-1 w-full cursor-row-resize"
+        isHorizontal ? "h-full w-px cursor-col-resize z-10" : "h-px w-full cursor-row-resize z-10"
       }`}
       onMouseDown={handleMouseDown}
       role="separator"
@@ -91,9 +91,15 @@ export function PaneResizeHandle({
       aria-valuemax={100 - MIN_PANE_SIZE}
       tabIndex={0}
     >
+      {/* Invisible expanded hit area for easier grabbing */}
       <div
-        className={`bg-border transition-colors ${
-          isDragging ? "bg-accent" : "group-hover:bg-accent"
+        className={`absolute ${isHorizontal ? "inset-y-0 -inset-x-2" : "inset-x-0 -inset-y-2"}`}
+      />
+
+      {/* Visible line */}
+      <div
+        className={`transition-colors ${
+          isDragging ? "bg-accent/80" : "bg-border/30 group-hover:bg-border/80"
         } ${isHorizontal ? "h-full w-px" : "h-px w-full"}`}
       />
       {isDragging && (

--- a/src/features/panes/components/pane-resize-handle.tsx
+++ b/src/features/panes/components/pane-resize-handle.tsx
@@ -25,6 +25,12 @@ export function PaneResizeHandle({ direction, onResize, initialSizes }: PaneResi
     [isHorizontal, initialSizes],
   );
 
+  const handleDoubleClick = useCallback(() => {
+    const pairTotal = initialSizes[0] + initialSizes[1];
+    const evenSize = pairTotal / 2;
+    onResize([evenSize, evenSize]);
+  }, [initialSizes, onResize]);
+
   useEffect(() => {
     if (!isDragging) return;
 
@@ -87,6 +93,7 @@ export function PaneResizeHandle({ direction, onResize, initialSizes }: PaneResi
       aria-valuemin={MIN_PANE_SIZE}
       aria-valuemax={100 - MIN_PANE_SIZE}
       tabIndex={0}
+      onDoubleClick={handleDoubleClick}
     >
       <div
         className={`bg-border transition-colors ${

--- a/src/features/panes/components/split-view-root.tsx
+++ b/src/features/panes/components/split-view-root.tsx
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useMemo } from "react";
 import { IS_MAC } from "@/utils/platform";
 import { usePaneStore } from "../stores/pane-store";
 import type { PaneNode, PaneSplit } from "../types/pane";
-import { getAllPaneGroups, getCollapsedSplitRepairs, normalizePanePairSizes } from "../utils/pane-tree";
+import {
+  getAllPaneGroups,
+  getCollapsedSplitRepairs,
+  normalizePanePairSizes,
+} from "../utils/pane-tree";
 import { PaneContainer } from "./pane-container";
 import { PaneResizeHandle } from "./pane-resize-handle";
 

--- a/src/features/panes/components/split-view-root.tsx
+++ b/src/features/panes/components/split-view-root.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import { IS_MAC } from "@/utils/platform";
 import { usePaneStore } from "../stores/pane-store";
 import type { PaneNode, PaneSplit } from "../types/pane";
-import { getAllPaneGroups } from "../utils/pane-tree";
+import { getAllPaneGroups, getCollapsedSplitRepairs, normalizePanePairSizes } from "../utils/pane-tree";
 import { PaneContainer } from "./pane-container";
 import { PaneResizeHandle } from "./pane-resize-handle";
 
@@ -117,6 +117,27 @@ function PaneNodeRenderer({ node }: PaneNodeRendererProps) {
     [flatEntries, updatePaneSizes],
   );
 
+  const handleFlatResizeEnd = useCallback(
+    (index: number, sizes: [number, number]) => {
+      if (!flatEntries) return;
+
+      const repairedSizes = normalizePanePairSizes(sizes);
+      const newSizes = flatEntries.map((entry) => entry.size);
+      newSizes[index] = repairedSizes[0];
+      newSizes[index + 1] = repairedSizes[1];
+
+      const updatedEntries = flatEntries.map((entry, entryIndex) => ({
+        ...entry,
+        size: newSizes[entryIndex],
+      }));
+
+      writeFlatSizesToTree(updatedEntries, (splitId, splitSizes) => {
+        updatePaneSizes(splitId, splitSizes);
+      });
+    },
+    [flatEntries, updatePaneSizes],
+  );
+
   if (node.type === "group") {
     return <PaneContainer pane={node} />;
   }
@@ -156,6 +177,7 @@ function PaneNodeRenderer({ node }: PaneNodeRendererProps) {
                 index={i}
                 entries={flatEntries}
                 onResize={handleFlatResize}
+                onResizeEnd={handleFlatResizeEnd}
               />
             )}
           </div>
@@ -170,9 +192,16 @@ interface FlatResizeHandleProps {
   index: number;
   entries: FlatEntry[];
   onResize: (index: number, sizes: [number, number]) => void;
+  onResizeEnd: (index: number, sizes: [number, number]) => void;
 }
 
-function FlatResizeHandle({ direction, index, entries, onResize }: FlatResizeHandleProps) {
+function FlatResizeHandle({
+  direction,
+  index,
+  entries,
+  onResize,
+  onResizeEnd,
+}: FlatResizeHandleProps) {
   const handleResize = useCallback(
     (sizes: [number, number]) => {
       onResize(index, sizes);
@@ -180,17 +209,30 @@ function FlatResizeHandle({ direction, index, entries, onResize }: FlatResizeHan
     [index, onResize],
   );
 
+  const handleResizeEnd = useCallback(
+    (sizes: [number, number]) => {
+      onResizeEnd(index, sizes);
+    },
+    [index, onResizeEnd],
+  );
+
   const initialSizes: [number, number] = [entries[index].size, entries[index + 1].size];
 
   return (
-    <PaneResizeHandle direction={direction} onResize={handleResize} initialSizes={initialSizes} />
+    <PaneResizeHandle
+      direction={direction}
+      onResize={handleResize}
+      onResizeEnd={handleResizeEnd}
+      initialSizes={initialSizes}
+    />
   );
 }
 
 export function SplitViewRoot() {
   const root = usePaneStore.use.root();
   const fullscreenPaneId = usePaneStore.use.fullscreenPaneId();
-  const { exitPaneFullscreen } = usePaneStore.use.actions();
+  const { exitPaneFullscreen, updatePaneSizes } = usePaneStore.use.actions();
+  const collapsedSplitRepairs = useMemo(() => getCollapsedSplitRepairs(root), [root]);
   const fullscreenPane = useMemo(
     () =>
       fullscreenPaneId
@@ -204,6 +246,14 @@ export function SplitViewRoot() {
       exitPaneFullscreen();
     }
   }, [exitPaneFullscreen, fullscreenPane, fullscreenPaneId]);
+
+  useEffect(() => {
+    if (collapsedSplitRepairs.length === 0) return;
+
+    collapsedSplitRepairs.forEach(({ splitId, sizes }) => {
+      updatePaneSizes(splitId, sizes);
+    });
+  }, [collapsedSplitRepairs, updatePaneSizes]);
 
   const titleBarHeight = IS_MAC ? 44 : 28;
   const footerHeight = 32;

--- a/src/features/panes/components/split-view-root.tsx
+++ b/src/features/panes/components/split-view-root.tsx
@@ -150,7 +150,7 @@ function PaneNodeRenderer({ node }: PaneNodeRendererProps) {
 
   // If only 2 entries (no flattening benefit), still use the flat approach for consistency
   const totalSize = flatEntries.reduce((sum, e) => sum + e.size, 0);
-  const handleWidth = 4; // w-1 = 4px
+  const handleWidth = 1; // w-px = 1px
   const handleCount = flatEntries.length - 1;
 
   return (

--- a/src/features/panes/constants/pane.ts
+++ b/src/features/panes/constants/pane.ts
@@ -1,4 +1,6 @@
-export const MIN_PANE_SIZE = 18;
+export const MIN_PANE_SIZE = 20;
+
+export const AUTO_REBALANCE_PRIMARY_SIZE = 40;
 
 export const DEFAULT_SPLIT_RATIO: [number, number] = [50, 50];
 

--- a/src/features/panes/constants/pane.ts
+++ b/src/features/panes/constants/pane.ts
@@ -1,4 +1,4 @@
-export const MIN_PANE_SIZE = 10;
+export const MIN_PANE_SIZE = 18;
 
 export const DEFAULT_SPLIT_RATIO: [number, number] = [50, 50];
 

--- a/src/features/panes/hooks/use-pane-keyboard.ts
+++ b/src/features/panes/hooks/use-pane-keyboard.ts
@@ -16,8 +16,8 @@ export function usePaneKeyboard() {
       if (e.key === "\\" && !e.shiftKey) {
         e.preventDefault();
         const activePane = paneStore.actions.getActivePane();
-        if (activePane?.activeBufferId) {
-          paneStore.actions.splitPane(activePane.id, "horizontal", activePane.activeBufferId);
+        if (activePane) {
+          paneStore.actions.splitPane(activePane.id, "horizontal");
         }
         return;
       }
@@ -26,8 +26,8 @@ export function usePaneKeyboard() {
       if (e.key === "\\" && e.shiftKey) {
         e.preventDefault();
         const activePane = paneStore.actions.getActivePane();
-        if (activePane?.activeBufferId) {
-          paneStore.actions.splitPane(activePane.id, "vertical", activePane.activeBufferId);
+        if (activePane) {
+          paneStore.actions.splitPane(activePane.id, "vertical");
         }
         return;
       }

--- a/src/features/panes/stores/pane-store.test.ts
+++ b/src/features/panes/stores/pane-store.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { ROOT_PANE_ID } from "../constants/pane";
+import type { PaneGroup } from "../types/pane";
+import { usePaneStore } from "./pane-store";
+
+function createRootPane(bufferIds: string[] = [], activeBufferId: string | null = null): PaneGroup {
+  return {
+    id: ROOT_PANE_ID,
+    type: "group",
+    bufferIds,
+    activeBufferId,
+  };
+}
+
+describe("pane-store splitPane", () => {
+  beforeEach(() => {
+    usePaneStore.getState().actions.reset();
+  });
+
+  test("creates an empty active pane when no buffer is provided", () => {
+    usePaneStore.setState({
+      root: createRootPane(["buffer-1"], "buffer-1"),
+      activePaneId: ROOT_PANE_ID,
+      fullscreenPaneId: null,
+    });
+
+    const newPaneId = usePaneStore.getState().actions.splitPane(ROOT_PANE_ID, "horizontal");
+    const state = usePaneStore.getState();
+
+    expect(newPaneId).not.toBeNull();
+    if (state.root.type !== "split" || !newPaneId) return;
+
+    expect(state.activePaneId).toBe(newPaneId);
+
+    const newPane = state.root.children.find((child) => child.id === newPaneId);
+    expect(newPane?.type).toBe("group");
+    if (!newPane || newPane.type !== "group") return;
+
+    expect(newPane.bufferIds).toEqual([]);
+    expect(newPane.activeBufferId).toBeNull();
+  });
+
+  test("seeds the new pane with the requested buffer when one is provided", () => {
+    usePaneStore.setState({
+      root: createRootPane(["buffer-1"], "buffer-1"),
+      activePaneId: ROOT_PANE_ID,
+      fullscreenPaneId: null,
+    });
+
+    const newPaneId = usePaneStore.getState().actions.splitPane(
+      ROOT_PANE_ID,
+      "horizontal",
+      "buffer-1",
+    );
+    const state = usePaneStore.getState();
+
+    expect(newPaneId).not.toBeNull();
+    if (state.root.type !== "split" || !newPaneId) return;
+
+    const newPane = state.root.children.find((child) => child.id === newPaneId);
+    expect(newPane?.type).toBe("group");
+    if (!newPane || newPane.type !== "group") return;
+
+    expect(newPane.bufferIds).toEqual(["buffer-1"]);
+    expect(newPane.activeBufferId).toBe("buffer-1");
+  });
+});

--- a/src/features/panes/stores/pane-store.test.ts
+++ b/src/features/panes/stores/pane-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "vite-plus/test";
 import { ROOT_PANE_ID } from "../constants/pane";
 import type { PaneGroup } from "../types/pane";
 import { usePaneStore } from "./pane-store";

--- a/src/features/panes/stores/pane-store.test.ts
+++ b/src/features/panes/stores/pane-store.test.ts
@@ -47,11 +47,9 @@ describe("pane-store splitPane", () => {
       fullscreenPaneId: null,
     });
 
-    const newPaneId = usePaneStore.getState().actions.splitPane(
-      ROOT_PANE_ID,
-      "horizontal",
-      "buffer-1",
-    );
+    const newPaneId = usePaneStore
+      .getState()
+      .actions.splitPane(ROOT_PANE_ID, "horizontal", "buffer-1");
     const state = usePaneStore.getState();
 
     expect(newPaneId).not.toBeNull();

--- a/src/features/panes/utils/pane-tree.test.ts
+++ b/src/features/panes/utils/pane-tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { getAdjacentPane, splitPane } from "./pane-tree";
+import { getAdjacentPane, getCollapsedSplitRepairs, normalizePanePairSizes, splitPane } from "./pane-tree";
 import type { PaneGroup, PaneNode } from "../types/pane";
 
 function createNamedPane(id: string): PaneGroup {
@@ -62,5 +62,45 @@ describe("getAdjacentPane", () => {
     expect(getAdjacentPane(root, "left", "right")?.id).toBe("top-right");
     expect(getAdjacentPane(root, "top-right", "down")?.id).toBe("bottom-right");
     expect(getAdjacentPane(root, "bottom-right", "up")?.id).toBe("top-right");
+  });
+});
+
+describe("normalizePanePairSizes", () => {
+  it("keeps healthy split sizes unchanged", () => {
+    expect(normalizePanePairSizes([50, 50])).toEqual([50, 50]);
+  });
+
+  it("repairs a collapsed first pane to a 40/60 split", () => {
+    expect(normalizePanePairSizes([19, 81])).toEqual([40, 60]);
+  });
+
+  it("repairs a collapsed second pane to a 60/40 split", () => {
+    expect(normalizePanePairSizes([81, 19])).toEqual([60, 40]);
+  });
+
+  it("keeps the 20% boundary unchanged", () => {
+    expect(normalizePanePairSizes([20, 80])).toEqual([20, 80]);
+  });
+});
+
+describe("getCollapsedSplitRepairs", () => {
+  it("collects repairs for collapsed splits in the tree", () => {
+    const left = createNamedPane("left");
+    const right = createNamedPane("right");
+
+    const root: PaneNode = {
+      id: "root-split",
+      type: "split",
+      direction: "horizontal",
+      children: [left, right],
+      sizes: [10, 90],
+    };
+
+    expect(getCollapsedSplitRepairs(root)).toEqual([
+      {
+        splitId: "root-split",
+        sizes: [40, 60],
+      },
+    ]);
   });
 });

--- a/src/features/panes/utils/pane-tree.test.ts
+++ b/src/features/panes/utils/pane-tree.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
-import { getAdjacentPane, getCollapsedSplitRepairs, normalizePanePairSizes, splitPane } from "./pane-tree";
+import {
+  getAdjacentPane,
+  getCollapsedSplitRepairs,
+  normalizePanePairSizes,
+  splitPane,
+} from "./pane-tree";
 import type { PaneGroup, PaneNode } from "../types/pane";
 
 function createNamedPane(id: string): PaneGroup {

--- a/src/features/panes/utils/pane-tree.ts
+++ b/src/features/panes/utils/pane-tree.ts
@@ -1,6 +1,11 @@
 import { nanoid } from "nanoid";
-import { DEFAULT_SPLIT_RATIO } from "../constants/pane";
+import { AUTO_REBALANCE_PRIMARY_SIZE, DEFAULT_SPLIT_RATIO, MIN_PANE_SIZE } from "../constants/pane";
 import type { PaneGroup, PaneNode, PaneSplit, SplitDirection, SplitPlacement } from "../types/pane";
+
+interface SplitSizeRepair {
+  splitId: string;
+  sizes: [number, number];
+}
 
 export function createPaneGroup(
   bufferIds: string[] = [],
@@ -126,6 +131,45 @@ export function splitPane(
   }
 
   return root;
+}
+
+export function normalizePanePairSizes(sizes: [number, number]): [number, number] {
+  const pairTotal = sizes[0] + sizes[1];
+  if (pairTotal <= 0) {
+    return sizes;
+  }
+
+  const minimumSize = (pairTotal * MIN_PANE_SIZE) / 100;
+  const primarySize = (pairTotal * AUTO_REBALANCE_PRIMARY_SIZE) / 100;
+  const secondarySize = pairTotal - primarySize;
+
+  if (sizes[0] < minimumSize) {
+    return [primarySize, secondarySize];
+  }
+
+  if (sizes[1] < minimumSize) {
+    return [secondarySize, primarySize];
+  }
+
+  return sizes;
+}
+
+export function getCollapsedSplitRepairs(root: PaneNode): SplitSizeRepair[] {
+  if (root.type === "group") {
+    return [];
+  }
+
+  const repairs = [
+    ...getCollapsedSplitRepairs(root.children[0]),
+    ...getCollapsedSplitRepairs(root.children[1]),
+  ];
+  const normalizedSizes = normalizePanePairSizes(root.sizes);
+
+  if (normalizedSizes[0] !== root.sizes[0] || normalizedSizes[1] !== root.sizes[1]) {
+    repairs.push({ splitId: root.id, sizes: normalizedSizes });
+  }
+
+  return repairs;
 }
 
 export function closePane(root: PaneNode, paneId: string): PaneNode | null {

--- a/src/features/tabs/components/tab-bar-item.tsx
+++ b/src/features/tabs/components/tab-bar-item.tsx
@@ -22,6 +22,7 @@ interface TabBarItemProps {
   displayName: string;
   index: number;
   isActive: boolean;
+  isPaneActive: boolean;
   isDraggedTab: boolean;
   showDropIndicatorBefore: boolean;
   tabRef: (el: HTMLDivElement | null) => void;
@@ -39,6 +40,7 @@ const TabBarItem = memo(function TabBarItem({
   buffer,
   displayName,
   isActive,
+  isPaneActive,
   isDraggedTab,
   showDropIndicatorBefore,
   tabRef,
@@ -83,7 +85,7 @@ const TabBarItem = memo(function TabBarItem({
         tabIndex={isActive ? 0 : -1}
         isActive={isActive}
         isDragged={isDraggedTab}
-        className={isActive ? "bg-hover/80" : undefined}
+        className={isActive ? (isPaneActive ? "bg-hover/80" : "bg-hover/30") : undefined}
         onMouseDown={onMouseDown}
         onDoubleClick={onDoubleClick}
         onContextMenu={onContextMenu}
@@ -178,7 +180,7 @@ const TabBarItem = memo(function TabBarItem({
         <span
           className={cn(
             "ui-font ui-text-sm max-w-full overflow-hidden text-ellipsis whitespace-nowrap",
-            isActive ? "text-text" : "text-text-lighter",
+            isActive && isPaneActive ? "text-text" : "text-text-lighter",
             buffer.isPreview && "italic",
           )}
           title={buffer.path}

--- a/src/features/tabs/components/tab-bar.tsx
+++ b/src/features/tabs/components/tab-bar.tsx
@@ -142,9 +142,9 @@ const TabBar = ({ paneId, onTabClick: externalTabClick }: TabBarProps) => {
   }, [jumpListActions]);
 
   const handleSplitActivePane = useCallback(() => {
-    if (!paneId || !activeBufferId) return;
-    splitPane(paneId, "horizontal", activeBufferId);
-  }, [activeBufferId, paneId, splitPane]);
+    if (!paneId) return;
+    splitPane(paneId, "horizontal");
+  }, [paneId, splitPane]);
 
   const handleTogglePaneFullscreen = useCallback(() => {
     if (!paneId) return;
@@ -816,15 +816,15 @@ const TabBar = ({ paneId, onTabClick: externalTabClick }: TabBarProps) => {
         </div>
 
         <div className="flex shrink-0 items-center gap-1 pl-0.5">
-          {paneId && activeBufferId && (
-            <Tooltip content="Split Editor" side="bottom">
+          {paneId && (
+            <Tooltip content="Split Pane" side="bottom">
               <Button
                 type="button"
                 onClick={handleSplitActivePane}
                 variant="ghost"
                 size="icon-sm"
                 className="shrink-0 rounded-lg text-text-lighter"
-                aria-label="Split editor"
+                aria-label="Split pane"
               >
                 <SplitSquareHorizontal />
               </Button>

--- a/src/features/tabs/components/tab-bar.tsx
+++ b/src/features/tabs/components/tab-bar.tsx
@@ -25,6 +25,7 @@ import TabDragPreview from "./tab-drag-preview";
 interface TabBarProps {
   paneId?: string;
   onTabClick?: (bufferId: string) => void;
+  isActivePane?: boolean;
 }
 
 const DRAG_THRESHOLD = 5;
@@ -37,7 +38,7 @@ interface TabPosition {
   center: number;
 }
 
-const TabBar = ({ paneId, onTabClick: externalTabClick }: TabBarProps) => {
+const TabBar = ({ paneId, onTabClick: externalTabClick, isActivePane = true }: TabBarProps) => {
   // Get everything from stores
   const allBuffers = useBufferStore.use.buffers();
   const globalActiveBufferId = useBufferStore.use.activeBufferId();
@@ -727,18 +728,15 @@ const TabBar = ({ paneId, onTabClick: externalTabClick }: TabBarProps) => {
 
   const MemoizedTabContextMenu = useMemo(() => TabContextMenu, []);
 
-  // Hide tab bar when no buffers are open
-  if (buffers.length === 0) {
-    return null;
-  }
-
   const { isDragging, draggedIndex, dropTargetIndex, currentPosition } = dragState;
 
   return (
     <>
       <div
         ref={tabBarRef}
-        className={`relative flex shrink-0 items-center gap-1 overflow-hidden bg-primary-bg px-1.5 py-1 ${isDropTarget ? "ring-2 ring-accent ring-inset" : ""}`}
+        className={`relative flex shrink-0 items-center gap-0.5 overflow-hidden bg-primary-bg px-1 py-1 border-b border-border/30 transition-opacity duration-200 ${
+          !isActivePane ? "opacity-60" : ""
+        } ${isDropTarget ? "ring-2 ring-accent ring-inset" : ""}`}
         role="tablist"
         aria-label="Open files"
         onWheel={handleWheel}
@@ -746,7 +744,7 @@ const TabBar = ({ paneId, onTabClick: externalTabClick }: TabBarProps) => {
         onDragLeave={handleTabBarDragLeave}
         onDrop={handleTabBarDrop}
       >
-        <div className="flex shrink-0 items-center gap-0.5">
+        <div className="hidden @sm:flex shrink-0 items-center gap-0.5">
           <Tooltip content="Go Back (Ctrl+-)" side="bottom">
             <Button
               type="button"
@@ -788,6 +786,7 @@ const TabBar = ({ paneId, onTabClick: externalTabClick }: TabBarProps) => {
                 displayName={displayNames.get(buffer.id) || buffer.name}
                 index={index}
                 isActive={isActive}
+                isPaneActive={isActivePane}
                 isDraggedTab={isDraggedTab}
                 showDropIndicatorBefore={showDropIndicatorBefore}
                 tabRef={(el) => {
@@ -816,37 +815,40 @@ const TabBar = ({ paneId, onTabClick: externalTabClick }: TabBarProps) => {
         </div>
 
         <div className="flex shrink-0 items-center gap-1 pl-0.5">
-          {paneId && (
-            <Tooltip content="Split Pane" side="bottom">
-              <Button
-                type="button"
-                onClick={handleSplitActivePane}
-                variant="ghost"
-                size="icon-sm"
-                className="shrink-0 rounded-lg text-text-lighter"
-                aria-label="Split pane"
+          <div className="hidden @sm:flex items-center gap-1">
+            {paneId && (
+              <Tooltip content="Split Pane" side="bottom">
+                <Button
+                  type="button"
+                  onClick={handleSplitActivePane}
+                  variant="ghost"
+                  size="icon-sm"
+                  className="shrink-0 rounded-lg text-text-lighter"
+                  id="split-editor-button"
+                  aria-label="Split pane"
+                >
+                  <SplitSquareHorizontal />
+                </Button>
+              </Tooltip>
+            )}
+            {paneId && (
+              <Tooltip
+                content={isPaneFullscreen ? "Exit Full Screen" : "Full Screen Editor"}
+                side="bottom"
               >
-                <SplitSquareHorizontal />
-              </Button>
-            </Tooltip>
-          )}
-          {paneId && (
-            <Tooltip
-              content={isPaneFullscreen ? "Exit Full Screen" : "Full Screen Editor"}
-              side="bottom"
-            >
-              <Button
-                type="button"
-                onClick={handleTogglePaneFullscreen}
-                variant="ghost"
-                size="icon-sm"
-                className="shrink-0 rounded-lg text-text-lighter"
-                aria-label="Toggle editor full screen"
-              >
-                {isPaneFullscreen ? <Minimize2 /> : <Maximize2 />}
-              </Button>
-            </Tooltip>
-          )}
+                <Button
+                  type="button"
+                  onClick={handleTogglePaneFullscreen}
+                  variant="ghost"
+                  size="icon-sm"
+                  className="shrink-0 rounded-lg text-text-lighter"
+                  aria-label="Toggle editor full screen"
+                >
+                  {isPaneFullscreen ? <Minimize2 /> : <Maximize2 />}
+                </Button>
+              </Tooltip>
+            )}
+          </div>
           <div className="flex shrink-0 items-center">
             <NewTabMenu />
           </div>

--- a/src/features/window/components/menu-bar/window-menu-bar.tsx
+++ b/src/features/window/components/menu-bar/window-menu-bar.tsx
@@ -109,7 +109,7 @@ const CustomMenuBar = ({ activeMenu, setActiveMenu, compactFloating = false }: P
             Toggle AI Chat
           </MenuItem>
           <MenuItem separator />
-          <MenuItem onClick={() => handleClickEmit("menu_split_editor")}>Split Editor</MenuItem>
+          <MenuItem onClick={() => handleClickEmit("menu_split_editor")}>Split Pane</MenuItem>
           <MenuItem separator />
           <MenuItem
             shortcut="Alt+M"

--- a/src/features/window/hooks/use-menu-events-wrapper.ts
+++ b/src/features/window/hooks/use-menu-events-wrapper.ts
@@ -123,8 +123,8 @@ export function useMenuEventsWrapper() {
     onSplitEditor: () => {
       const paneStore = usePaneStore.getState();
       const activePane = paneStore.actions.getActivePane();
-      if (activePane?.activeBufferId) {
-        paneStore.actions.splitPane(activePane.id, "horizontal", activePane.activeBufferId);
+      if (activePane) {
+        paneStore.actions.splitPane(activePane.id, "horizontal");
       }
     },
     onToggleVim: () => {


### PR DESCRIPTION
## Summary

This pulls the split-pane work out into its own PR instead of burying it inside the larger Pi/Harness parity branch.

It does three things:
- prevents split panes from collapsing into unusable slivers and auto-repairs bad restored ratios
- changes generic split actions to create a new empty pane instead of duplicating the active tab
- polishes split-pane UI so empty panes, active focus, resize handles, and narrow layouts feel intentional

## What changed

### Split sizing and recovery
- raise the minimum pane threshold to 20%
- normalize collapsed split pairs to 40/60 on drag release
- repair previously bad split ratios on restore/startup

### Split semantics
- generic split actions now open an empty pane and focus it
- tab-context split actions still open the selected tab in the new pane
- generic UI copy now says `Split Pane`

### Split UI polish
- always show structural tab chrome for empty panes
- make active pane focus clearer with calmer hierarchy
- slim the resize handle visually while keeping a generous hit area
- hide nonessential tab chrome in narrow panes so cramped splits stay usable

## Verification

Ran on this branch:
- `bun typecheck`
- `bun lint`
- `bunx vp test run src/features/panes/stores/pane-store.test.ts src/features/panes/utils/pane-tree.test.ts`
- `bunx vp build`
- `git diff --check`

Watched-app verification used the existing local X11/VNC flow and screenshots:
- `/tmp/athas-split-empty-after-key.png`
- `/tmp/athas-empty-split-normal.png`
- `/tmp/athas-empty-split-narrow.png`
- `/tmp/athas-tab-context-split.png`

## Notes

The repo's full pre-push gate on this branch still trips over upstream `master` Rust issues that are unrelated to this PR:
- `cargo fmt --check --all` reports formatting drift in `crates/runtime` and `crates/tooling`
- `cargo check --workspace` fails on Linux in `src-tauri/src/commands/ui/window.rs` because `hidden_title(...)` is not available on this target

I left those out of this PR on purpose so the split-pane extraction stays scoped.
