### PR TITLE
Add GitHub Copilot provider with OAuth device flow

### DIFF
--- a/src-tauri/src/app_setup.rs
+++ b/src-tauri/src/app_setup.rs
@@ -8,6 +8,7 @@ use athas_ai::AcpAgentBridge;
 use athas_database::ConnectionManager;
 use athas_lsp::LspManager;
 use athas_project::FileWatcher;
+use commands::ai::copilot::CopilotState;
 use log::{debug, info};
 use std::sync::Arc;
 use tauri::{Emitter, Manager, Wry};
@@ -69,6 +70,7 @@ fn register_managed_state(app: &mut tauri::App<Wry>) {
    app.manage(ThemeCache::new(std::collections::HashMap::new()));
    app.manage(FileClipboard::new(None));
    app.manage(Arc::new(ConnectionManager::new()));
+   app.manage(CopilotState::new());
 }
 
 fn emit_cli_open_requests(app: &tauri::App<Wry>) {

--- a/src-tauri/src/commands/ai/copilot.rs
+++ b/src-tauri/src/commands/ai/copilot.rs
@@ -1,0 +1,262 @@
+use crate::secure_storage::{get_secret, remove_secret, store_secret};
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, command};
+
+const GITHUB_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+const DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
+const TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+const COPILOT_TOKEN_URL: &str = "https://api.github.com/copilot_internal/v2/token";
+const COPILOT_OAUTH_KEY: &str = "ai_token_copilot";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct DeviceCodeResponse {
+   device_code: String,
+   user_code: String,
+   verification_uri: String,
+   expires_in: u64,
+   interval: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct CopilotTokenResponse {
+   token: String,
+   expires_at: i64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct CopilotAuthStatus {
+   is_authenticated: bool,
+   user_login: Option<String>,
+}
+
+struct CopilotTokenCache {
+   token: Option<String>,
+   expires_at: Option<i64>,
+}
+
+pub struct CopilotState {
+   cache: Mutex<CopilotTokenCache>,
+}
+
+impl CopilotState {
+   pub fn new() -> Self {
+      Self {
+         cache: Mutex::new(CopilotTokenCache {
+            token: None,
+            expires_at: None,
+         }),
+      }
+   }
+}
+
+#[command]
+pub async fn copilot_start_device_flow(app: AppHandle) -> Result<DeviceCodeResponse, String> {
+   let client = reqwest::Client::new();
+   let response = client
+      .post(DEVICE_CODE_URL)
+      .header("Accept", "application/json")
+      .form(&[("client_id", GITHUB_CLIENT_ID), ("scope", "copilot")])
+      .send()
+      .await
+      .map_err(|e| format!("Failed to request device code: {e}"))?;
+
+   let code_response: DeviceCodeResponse = response
+      .json()
+      .await
+      .map_err(|e| format!("Failed to parse device code response: {e}"))?;
+
+   // Store device_code temporarily for polling
+   store_secret(&app, "copilot_device_code", &code_response.device_code)
+      .map_err(|e| format!("Failed to store device code: {e}"))?;
+
+   Ok(code_response)
+}
+
+#[command]
+pub async fn copilot_poll_device_token(app: AppHandle) -> Result<Option<String>, String> {
+   let device_code = get_secret(&app, "copilot_device_code")?;
+   let device_code = device_code.ok_or("No device code found. Start the device flow first.")?;
+
+   let client = reqwest::Client::new();
+   let response = client
+      .post(TOKEN_URL)
+      .header("Accept", "application/json")
+      .form(&[
+         ("client_id", GITHUB_CLIENT_ID),
+         ("device_code", &device_code),
+         ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+      ])
+      .send()
+      .await
+      .map_err(|e| format!("Failed to poll for token: {e}"))?;
+
+   let body: serde_json::Value = response
+      .json()
+      .await
+      .map_err(|e| format!("Failed to parse token response: {e}"))?;
+
+   if let Some(error) = body.get("error") {
+      let error_str = error.as_str().unwrap_or("unknown_error");
+      match error_str {
+         "authorization_pending" => Ok(None),
+         "slow_down" => Ok(None),
+         "expired_token" => {
+            let _ = remove_secret(&app, "copilot_device_code");
+            Err("Device code expired. Please start the flow again.".to_string())
+         }
+         _ => Err(format!(
+            "Authentication failed: {}",
+            body
+               .get("error_description")
+               .and_then(|v| v.as_str())
+               .unwrap_or(error_str)
+         )),
+      }
+   } else if let Some(access_token) = body.get("access_token").and_then(|v| v.as_str()) {
+      // Store the OAuth token in keychain
+      store_secret(&app, COPILOT_OAUTH_KEY, access_token)
+         .map_err(|e| format!("Failed to store Copilot token: {e}"))?;
+
+      // Clean up the device code
+      let _ = remove_secret(&app, "copilot_device_code");
+
+      Ok(Some(access_token.to_string()))
+   } else {
+      Err("Unexpected response from GitHub".to_string())
+   }
+}
+
+#[command]
+pub async fn copilot_get_auth_status(app: AppHandle) -> Result<CopilotAuthStatus, String> {
+   let oauth_token = get_secret(&app, COPILOT_OAUTH_KEY)?;
+
+   match oauth_token {
+      Some(token) => {
+         // Validate by trying to get a Copilot API token
+         let client = reqwest::Client::new();
+         let response = client
+            .get(COPILOT_TOKEN_URL)
+            .header("Authorization", format!("token {token}"))
+            .header("Accept", "application/json")
+            .header("Editor-Version", "athas/0.4.5")
+            .header("Editor-Plugin-Version", "copilot/1.0.0")
+            .header("Copilot-Integration-Id", "vscode-chat")
+            .send()
+            .await;
+
+         match response {
+            Ok(resp) if resp.status().is_success() => {
+               let token_resp: serde_json::Value = resp
+                  .json()
+                  .await
+                  .map_err(|e| format!("Failed to parse Copilot token: {e}"))?;
+
+               let user_login = token_resp
+                  .get("login")
+                  .and_then(|v| v.as_str())
+                  .map(|s| s.to_string());
+
+               Ok(CopilotAuthStatus {
+                  is_authenticated: true,
+                  user_login,
+               })
+            }
+            Ok(resp) if resp.status().as_u16() == 401 => {
+               // Token is invalid/expired — remove it
+               let _ = remove_secret(&app, COPILOT_OAUTH_KEY);
+               Ok(CopilotAuthStatus {
+                  is_authenticated: false,
+                  user_login: None,
+               })
+            }
+            _ => {
+               // Network error or other issue — still consider authenticated
+               // (the OAuth token exists, we just can't verify right now)
+               Ok(CopilotAuthStatus {
+                  is_authenticated: true,
+                  user_login: None,
+               })
+            }
+         }
+      }
+      None => Ok(CopilotAuthStatus {
+         is_authenticated: false,
+         user_login: None,
+      }),
+   }
+}
+
+#[command]
+pub async fn copilot_get_api_token(app: AppHandle) -> Result<String, String> {
+   // Check in-memory cache first
+   let copilot_state = app.state::<CopilotState>();
+   {
+      let cache = copilot_state.cache.lock().map_err(|e| e.to_string())?;
+      if let (Some(token), Some(expires_at)) = (&cache.token, cache.expires_at) {
+         let now = chrono::Utc::now().timestamp();
+         // Use 5-minute buffer before expiry
+         if now < expires_at - 300 {
+            return Ok(token.clone());
+         }
+      }
+   }
+
+   // Cache miss or expired — fetch from Copilot API
+   let oauth_token = get_secret(&app, COPILOT_OAUTH_KEY)?;
+   let oauth_token =
+      oauth_token.ok_or("Not authenticated with GitHub Copilot. Please sign in first.")?;
+
+   let client = reqwest::Client::new();
+   let response = client
+      .get(COPILOT_TOKEN_URL)
+      .header("Authorization", format!("token {oauth_token}"))
+      .header("Accept", "application/json")
+      .header("Editor-Version", "athas/0.4.5")
+      .header("Editor-Plugin-Version", "copilot/1.0.0")
+      .header("Copilot-Integration-Id", "vscode-chat")
+      .send()
+      .await
+      .map_err(|e| format!("Failed to get Copilot API token: {e}"))?;
+
+   if response.status().as_u16() == 401 {
+      // OAuth token is invalid — remove it
+      let _ = remove_secret(&app, COPILOT_OAUTH_KEY);
+      return Err("GitHub Copilot authentication expired. Please sign in again.".to_string());
+   }
+
+   if !response.status().is_success() {
+      return Err(format!(
+         "Failed to get Copilot API token: {}",
+         response.status()
+      ));
+   }
+
+   let token_resp: CopilotTokenResponse = response
+      .json()
+      .await
+      .map_err(|e| format!("Failed to parse Copilot API token: {e}"))?;
+
+   // Update in-memory cache
+   {
+      let mut cache = copilot_state.cache.lock().map_err(|e| e.to_string())?;
+      cache.token = Some(token_resp.token.clone());
+      cache.expires_at = Some(token_resp.expires_at);
+   }
+
+   Ok(token_resp.token)
+}
+
+#[command]
+pub async fn copilot_logout(app: AppHandle) -> Result<(), String> {
+   // Remove OAuth token from keychain
+   remove_secret(&app, COPILOT_OAUTH_KEY)?;
+
+   // Clear in-memory cache
+   let copilot_state = app.state::<CopilotState>();
+   let mut cache = copilot_state.cache.lock().map_err(|e| e.to_string())?;
+   cache.token = None;
+   cache.expires_at = None;
+
+   Ok(())
+}

--- a/src-tauri/src/commands/ai/mod.rs
+++ b/src-tauri/src/commands/ai/mod.rs
@@ -1,9 +1,11 @@
 pub mod acp;
 pub mod auth;
 pub mod chat_history;
+pub mod copilot;
 pub mod tokens;
 
 pub use acp::*;
 pub use auth::*;
 pub use chat_history::*;
+pub use copilot::*;
 pub use tokens::*;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -129,6 +129,12 @@ fn main() {
          delete_chat,
          search_chats,
          get_chat_stats,
+         // Copilot commands
+         copilot_start_device_flow,
+         copilot_poll_device_token,
+         copilot_get_auth_status,
+         copilot_get_api_token,
+         copilot_logout,
          // Window commands
          create_app_window,
          create_embedded_webview,

--- a/src/features/ai/components/copilot-auth-modal.tsx
+++ b/src/features/ai/components/copilot-auth-modal.tsx
@@ -1,0 +1,295 @@
+import { invoke } from "@tauri-apps/api/core";
+import { motion } from "framer-motion";
+import { AlertCircle, CheckCircle, Copy, ExternalLink, Loader2, LogIn, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/ui/button";
+
+type AuthStep = "idle" | "device_code" | "polling" | "success" | "error";
+
+interface CopilotAuthModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAuthComplete: () => void;
+}
+
+export function CopilotAuthModal({ isOpen, onClose, onAuthComplete }: CopilotAuthModalProps) {
+  const [step, setStep] = useState<AuthStep>("idle");
+  const [userCode, setUserCode] = useState("");
+  const [verificationUri, setVerificationUri] = useState("");
+  const [countdown, setCountdown] = useState(0);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [copied, setCopied] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const cleanup = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    if (countdownRef.current) {
+      clearInterval(countdownRef.current);
+      countdownRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return cleanup;
+  }, [cleanup]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      cleanup();
+      setStep("idle");
+      setUserCode("");
+      setVerificationUri("");
+      setCountdown(0);
+      setErrorMessage("");
+      setCopied(false);
+    }
+  }, [isOpen, cleanup]);
+
+  const handleStartFlow = async () => {
+    try {
+      setStep("device_code");
+      setErrorMessage("");
+
+      const response = await invoke<{
+        device_code: string;
+        user_code: string;
+        verification_uri: string;
+        expires_in: number;
+        interval: number;
+      }>("copilot_start_device_flow");
+
+      setUserCode(response.user_code);
+      setVerificationUri(response.verification_uri);
+      setCountdown(response.expires_in);
+
+      // Start countdown
+      const expiresAt = Date.now() + response.expires_in * 1000;
+      countdownRef.current = setInterval(() => {
+        const remaining = Math.max(0, Math.floor((expiresAt - Date.now()) / 1000));
+        setCountdown(remaining);
+        if (remaining <= 0) {
+          if (countdownRef.current) clearInterval(countdownRef.current);
+          setStep("error");
+          setErrorMessage("Device code expired. Please try again.");
+          cleanup();
+        }
+      }, 1000);
+
+      // Start polling
+      setStep("polling");
+      const pollInterval = response.interval * 1000;
+      pollRef.current = setInterval(async () => {
+        try {
+          const result = await invoke<string | null>("copilot_poll_device_token");
+          if (result !== null) {
+            cleanup();
+            setStep("success");
+            onAuthComplete();
+            setTimeout(() => onClose(), 1500);
+          }
+        } catch (err: any) {
+          cleanup();
+          setStep("error");
+          setErrorMessage(err?.toString() || "Authentication failed");
+        }
+      }, pollInterval);
+    } catch (err: any) {
+      setStep("error");
+      setErrorMessage(err?.toString() || "Failed to start device flow");
+    }
+  };
+
+  const handleCopyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(userCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback
+    }
+  };
+
+  const formatCountdown = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.15 }}
+      className="fixed inset-0 z-150 flex items-center justify-center bg-black/50"
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.15, ease: "easeOut" }}
+        className="flex max-h-[90vh] w-[480px] flex-col rounded-lg border border-border bg-primary-bg"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-border border-b p-4">
+          <div className="flex items-center gap-2">
+            <LogIn className="text-text" />
+            <h3 className="ui-font text-sm text-text">GitHub Copilot Authentication</h3>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onClose}
+            className="text-text-lighter hover:text-text"
+          >
+            <X />
+          </Button>
+        </div>
+
+        <div className="flex-1 space-y-4 overflow-y-auto p-4">
+          {step === "idle" && (
+            <>
+              <div className="text-text-lighter text-xs leading-relaxed">
+                Sign in with your GitHub account to access Copilot&apos;s AI models. Requires an
+                active GitHub Copilot subscription (Individual, Business, or Enterprise).
+              </div>
+              <div className="rounded border border-border bg-secondary-bg p-3">
+                <div className="mb-2 font-medium text-text text-xs">
+                  How it works:
+                </div>
+                <ol className="list-inside list-decimal space-y-1 text-text-lighter text-xs">
+                  <li>Click &quot;Sign in with GitHub&quot; to get a device code</li>
+                  <li>Open the verification URL and enter the code</li>
+                  <li>Authorize Athas in your GitHub account</li>
+                  <li>Start using Copilot models in chat</li>
+                </ol>
+              </div>
+            </>
+          )}
+
+          {(step === "device_code" || step === "polling") && (
+            <>
+              <div className="text-text-lighter text-xs leading-relaxed">
+                Open the URL below and enter this code to authorize Athas:
+              </div>
+
+              <div className="space-y-3 rounded border border-border bg-secondary-bg p-4">
+                <div>
+                  <div className="mb-1 font-medium text-text text-xs">Verification URL:</div>
+                  <a
+                    href={verificationUri}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-blue-400 text-sm transition-colors hover:text-blue-300"
+                  >
+                    {verificationUri}
+                    <ExternalLink />
+                  </a>
+                </div>
+
+                <div>
+                  <div className="mb-1 font-medium text-text text-xs">Device Code:</div>
+                  <div className="flex items-center gap-2">
+                    <code className="rounded bg-primary-bg px-3 py-1.5 font-mono text-lg tracking-widest text-text">
+                      {userCode}
+                    </code>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      onClick={handleCopyCode}
+                      className="gap-1 text-text-lighter"
+                    >
+                      {copied ? <CheckCircle /> : <Copy />}
+                      {copied ? "Copied" : "Copy"}
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between border-border border-t pt-2">
+                  <span className="text-text-lighter text-xs">
+                    Expires in {formatCountdown(countdown)}
+                  </span>
+                  {step === "polling" && (
+                    <span className="flex items-center gap-1 text-text-lighter text-xs">
+                      <Loader2 className="size-3 animate-spin" />
+                      Waiting for authorization...
+                    </span>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+
+          {step === "success" && (
+            <div className="flex flex-col items-center gap-3 py-4">
+              <CheckCircle className="size-10 text-green-500" />
+              <div className="font-medium text-text text-sm">Successfully authenticated!</div>
+              <div className="text-text-lighter text-xs">
+                You can now use GitHub Copilot models in chat.
+              </div>
+            </div>
+          )}
+
+          {step === "error" && (
+            <div className="flex flex-col items-center gap-3 py-4">
+              <AlertCircle className="size-10 text-red-400" />
+              <div className="font-medium text-text text-sm">Authentication failed</div>
+              <div className="text-red-400 text-xs">{errorMessage}</div>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 border-border border-t p-4">
+          {step === "idle" && (
+            <>
+              <Button onClick={handleStartFlow} className="flex-1 gap-2">
+                <LogIn />
+                Sign in with GitHub
+              </Button>
+              <Button onClick={onClose} variant="ghost" className="px-4">
+                Cancel
+              </Button>
+            </>
+          )}
+
+          {(step === "device_code" || step === "polling") && (
+            <Button
+              onClick={() => {
+                cleanup();
+                onClose();
+              }}
+              variant="ghost"
+              className="flex-1"
+            >
+              Cancel
+            </Button>
+          )}
+
+          {step === "error" && (
+            <>
+              <Button
+                onClick={() => {
+                  setStep("idle");
+                  setErrorMessage("");
+                }}
+                className="flex-1"
+              >
+                Try Again
+              </Button>
+              <Button onClick={onClose} variant="ghost" className="px-4">
+                Cancel
+              </Button>
+            </>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/features/ai/components/icons/provider-icons.tsx
+++ b/src/features/ai/components/icons/provider-icons.tsx
@@ -105,6 +105,14 @@ export function CustomAPIIcon({ size, className, ...props }: IconProps) {
   );
 }
 
+export function CopilotIcon({ size, className, ...props }: IconProps) {
+  return (
+    <svg aria-hidden="true" {...defaultProps(size, className)} {...props}>
+      <path d="M8 12a4 4 0 1 0 8 0 4 4 0 0 0-8 0zm4-10C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm0 2a8 8 0 0 1 4.891 1.672 7.04 7.04 0 0 0-3.083 5.324H10.19a7.04 7.04 0 0 0-3.082-5.324A8 8 0 0 1 12 4zm-6.316 3.42a5.036 5.036 0 0 1 2.25 3.576H4.069A8.02 8.02 0 0 1 5.684 7.42zm12.632 0A8.02 8.02 0 0 1 19.93 11h-3.865a5.036 5.036 0 0 1 2.25-3.58zM9.49 14h5.02a5.036 5.036 0 0 1-2.251 3.576A5.036 5.036 0 0 1 9.49 14zm-5.422 0h3.866a7.04 7.04 0 0 0 3.082 5.324A8.004 8.004 0 0 1 4.069 14zm11.994 0h3.866a8.004 8.004 0 0 1-6.948 5.324A7.04 7.04 0 0 0 16.063 14z" />
+    </svg>
+  );
+}
+
 export function ProviderIcon({
   providerId,
   size = 14,
@@ -139,6 +147,8 @@ export function ProviderIcon({
       return <OpenRouterIcon {...props} />;
     case "kimi-cli":
       return <MoonshotIcon {...props} />;
+    case "copilot":
+      return <CopilotIcon {...props} />;
     case "qwen-code":
       return <QwenIcon {...props} />;
     case "opencode":

--- a/src/features/ai/components/selectors/provider-model-selector.tsx
+++ b/src/features/ai/components/selectors/provider-model-selector.tsx
@@ -9,6 +9,8 @@ import {
   Globe,
   Key,
   Lock,
+  LogIn,
+  LogOut,
   RefreshCw,
   Search,
   Trash2,
@@ -24,6 +26,7 @@ import {
   useState,
 } from "react";
 import { ProviderIcon } from "@/features/ai/components/icons/provider-icons";
+import { CopilotAuthModal } from "@/features/ai/components/copilot-auth-modal";
 import { useAIChatStore } from "@/features/ai/store/store";
 import {
   getAvailableProviders,
@@ -96,8 +99,12 @@ export function ProviderModelSelector({
   const [ollamaUrlStatus, setOllamaUrlStatus] = useState<"idle" | "checking" | "ok" | "error">(
     "idle",
   );
+  const [copilotAuthModalOpen, setCopilotAuthModalOpen] = useState(false);
 
   const { isPro } = useProFeature();
+  const copilotAuthStatus = useAIChatStore((state) => state.copilotAuthStatus);
+  const checkCopilotAuth = useAIChatStore((state) => state.checkCopilotAuth);
+  const copilotLogoutAction = useAIChatStore((state) => state.copilotLogout);
   const { dynamicModels, setDynamicModels } = useAIChatStore();
   const hasProviderApiKey = useAIChatStore((state) => state.hasProviderApiKey);
   const saveApiKey = useAIChatStore((state) => state.saveApiKey);
@@ -128,7 +135,12 @@ export function ProviderModelSelector({
 
     setModelFetchError(null);
 
-    if (!instance?.getModels || config?.requiresApiKey) {
+    if (!instance?.getModels || (config?.requiresApiKey && !hasProviderApiKey(providerId))) {
+      return;
+    }
+
+    // Copilot needs auth but not an API key
+    if (providerId === "copilot" && !copilotAuthStatus.isAuthenticated) {
       return;
     }
 
@@ -168,7 +180,8 @@ export function ProviderModelSelector({
     const searchLower = search.toLowerCase();
 
     for (const provider of providers) {
-      const providerHasKey = !provider.requiresApiKey || hasProviderApiKey(provider.id);
+      const providerHasKey = !provider.requiresApiKey || hasProviderApiKey(provider.id) ||
+        (provider.id === "copilot" && copilotAuthStatus.isAuthenticated);
       const models = dynamicModels[provider.id] || provider.models;
       const providerNameMatches = provider.name.toLowerCase().includes(searchLower);
 
@@ -622,6 +635,37 @@ export function ProviderModelSelector({
                             Set URL
                           </Button>
                         )}
+
+                        {item.providerId === "copilot" && !isEditing && (
+                          copilotAuthStatus.isAuthenticated ? (
+                            <>
+                              <CheckCircle className="size-3 text-success" />
+                              <Button
+                                type="button"
+                                onClick={() => void copilotLogoutAction()}
+                                variant="ghost"
+                                size="xs"
+                                className="h-auto px-1.5 text-[10px] text-text-lighter hover:text-error"
+                                aria-label="Sign out of Copilot"
+                              >
+                                <LogOut />
+                                Sign Out
+                              </Button>
+                            </>
+                          ) : (
+                            <Button
+                              type="button"
+                              onClick={() => setCopilotAuthModalOpen(true)}
+                              variant="primary"
+                              size="xs"
+                              className="h-auto gap-1 px-1.5 text-[10px]"
+                              aria-label="Authenticate with GitHub Copilot"
+                            >
+                              <LogIn />
+                              Authenticate
+                            </Button>
+                          )
+                        )}
                       </div>
                     </div>
 
@@ -819,6 +863,12 @@ export function ProviderModelSelector({
           )}
         </div>
       </MenuPopover>
+
+      <CopilotAuthModal
+        isOpen={copilotAuthModalOpen}
+        onClose={() => setCopilotAuthModalOpen(false)}
+        onAuthComplete={() => void checkCopilotAuth()}
+      />
     </div>
   );
 }

--- a/src/features/ai/services/ai-chat-service.ts
+++ b/src/features/ai/services/ai-chat-service.ts
@@ -1,4 +1,5 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { invoke } from "@tauri-apps/api/core";
 import { useAIChatStore } from "@/features/ai/store/store";
 import type { ChatMode, OutputStyle } from "@/features/ai/store/types";
 import type { AcpEvent } from "@/features/ai/types/acp";
@@ -7,6 +8,7 @@ import { AGENT_OPTIONS, type AgentType } from "@/features/ai/types/ai-chat";
 import type { AIMessage } from "@/features/ai/types/messages";
 import { getModelById, getProviderById } from "@/features/ai/types/providers";
 import { getProvider } from "@/features/ai/services/providers/ai-provider-registry";
+import type { ProviderHeaders } from "@/features/ai/services/providers/ai-provider-interface";
 import { processStreamingResponse } from "@/utils/stream-utils";
 import { getProviderApiToken } from "@/features/ai/services/ai-token-service";
 import { AcpStreamHandler } from "./acp-stream-handler";
@@ -89,6 +91,19 @@ export const getChatCompletionStream = async (
       throw new Error(`${provider.name} API key not found`);
     }
 
+    // Copilot uses OAuth — skip API key requirement
+    if (providerId === "copilot") {
+      try {
+        const status = await invoke<{ is_authenticated: boolean }>("copilot_get_auth_status");
+        if (!status.is_authenticated) {
+          throw new Error("GitHub Copilot not authenticated. Please sign in first.");
+        }
+      } catch (err: any) {
+        if (err.message?.includes("not authenticated")) throw err;
+        throw new Error("Failed to check GitHub Copilot authentication status.");
+      }
+    }
+
     const contextPrompt = buildContextPrompt(context);
     const systemPrompt = buildSystemPrompt(contextPrompt, mode, outputStyle);
 
@@ -125,7 +140,13 @@ export const getChatCompletionStream = async (
       apiKey: apiKey || undefined,
     };
 
-    const headers = providerImpl.buildHeaders(apiKey || undefined);
+    // Use async headers if available (e.g., Copilot OAuth token refresh)
+    let headers: ProviderHeaders;
+    if (typeof providerImpl.buildHeadersAsync === "function") {
+      headers = await providerImpl.buildHeadersAsync(apiKey || undefined);
+    } else {
+      headers = providerImpl.buildHeaders(apiKey || undefined);
+    }
     const payload = providerImpl.buildPayload(streamRequest);
     const url = providerImpl.buildUrl ? providerImpl.buildUrl(streamRequest) : provider.apiUrl;
 
@@ -133,7 +154,7 @@ export const getChatCompletionStream = async (
 
     // Use Tauri's fetch for providers that don't support browser CORS
     const needsTauriFetch =
-      providerId === "gemini" || providerId === "ollama" || providerId === "anthropic";
+      providerId === "gemini" || providerId === "ollama" || providerId === "anthropic" || providerId === "copilot";
     const fetchFn = needsTauriFetch ? tauriFetch : fetch;
     const response = await fetchFn(url, {
       method: "POST",

--- a/src/features/ai/services/ai-token-service.ts
+++ b/src/features/ai/services/ai-token-service.ts
@@ -59,3 +59,26 @@ export const validateProviderApiKey = async (
     return false;
   }
 };
+
+// Copilot auth helpers
+export const getCopilotAuthStatus = async (): Promise<{
+  isAuthenticated: boolean;
+  userLogin?: string;
+}> => {
+  try {
+    const status = await invoke<{
+      is_authenticated: boolean;
+      user_login?: string;
+    }>("copilot_get_auth_status");
+    return {
+      isAuthenticated: status.is_authenticated,
+      userLogin: status.user_login || undefined,
+    };
+  } catch {
+    return { isAuthenticated: false };
+  }
+};
+
+export const copilotLogout = async (): Promise<void> => {
+  await invoke("copilot_logout");
+};

--- a/src/features/ai/services/providers/ai-provider-interface.ts
+++ b/src/features/ai/services/providers/ai-provider-interface.ts
@@ -42,6 +42,9 @@ export abstract class AIProvider {
     return [];
   }
 
+  // Optional: Allows providers to build headers asynchronously (e.g., OAuth token refresh)
+  async buildHeadersAsync?(apiKey?: string): Promise<ProviderHeaders>;
+
   get id(): string {
     return this.config.id;
   }

--- a/src/features/ai/services/providers/ai-provider-registry.ts
+++ b/src/features/ai/services/providers/ai-provider-registry.ts
@@ -1,4 +1,5 @@
 import { AnthropicProvider } from "./anthropic-provider";
+import { CopilotProvider } from "./copilot-provider";
 import { GeminiProvider } from "./gemini-provider";
 import { GrokProvider } from "./grok-provider";
 import { OllamaProvider } from "./ollama-provider";
@@ -62,6 +63,15 @@ function initializeProviders(): void {
     maxTokens: 4096,
   };
   providers.set("ollama", new OllamaProvider(ollamaConfig));
+
+  const copilotConfig: ProviderConfig = {
+    id: "copilot",
+    name: "GitHub Copilot",
+    apiUrl: "https://api.githubcopilot.com/chat/completions",
+    requiresApiKey: false,
+    maxTokens: 128000,
+  };
+  providers.set("copilot", new CopilotProvider(copilotConfig));
 }
 
 export function getProvider(providerId: string): AIProvider | undefined {

--- a/src/features/ai/services/providers/copilot-provider.ts
+++ b/src/features/ai/services/providers/copilot-provider.ts
@@ -1,0 +1,73 @@
+import { invoke } from "@tauri-apps/api/core";
+import {
+  AIProvider,
+  type ProviderHeaders,
+  type ProviderModel,
+  type StreamRequest,
+} from "./ai-provider-interface";
+
+export class CopilotProvider extends AIProvider {
+  buildHeaders(_apiKey?: string): ProviderHeaders {
+    return {
+      "Content-Type": "application/json",
+    };
+  }
+
+  async buildHeadersAsync(_apiKey?: string): Promise<ProviderHeaders> {
+    const token = await invoke<string>("copilot_get_api_token");
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+      "X-Request-Id": crypto.randomUUID(),
+      "Copilot-Integration-Id": "vscode-chat",
+      "Editor-Version": "athas/0.4.5",
+      "Editor-Plugin-Version": "copilot/1.0.0",
+    };
+  }
+
+  buildPayload(request: StreamRequest): any {
+    return {
+      model: request.modelId,
+      messages: request.messages,
+      stream: true,
+      temperature: request.temperature,
+      max_tokens: request.maxTokens,
+    };
+  }
+
+  async validateApiKey(_apiKey?: string): Promise<boolean> {
+    try {
+      const status = await invoke<{ is_authenticated: boolean }>("copilot_get_auth_status");
+      return status.is_authenticated;
+    } catch {
+      return false;
+    }
+  }
+
+  buildUrl(_request?: StreamRequest): string {
+    return "https://api.githubcopilot.com/chat/completions";
+  }
+
+  async getModels(): Promise<ProviderModel[]> {
+    try {
+      const token = await invoke<string>("copilot_get_api_token");
+      const response = await fetch("https://api.githubcopilot.com/models", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "Copilot-Integration-Id": "vscode-chat",
+          "Editor-Version": "athas/0.4.5",
+        },
+      });
+      if (!response.ok) return [];
+      const data = await response.json();
+      return (data.data || []).map((m: any) => ({
+        id: m.id || m.name,
+        name: m.name || m.id,
+        maxTokens: m.max_tokens || 128000,
+      }));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/src/features/ai/store/store.ts
+++ b/src/features/ai/store/store.ts
@@ -48,6 +48,10 @@ export const useAIChatStore = create<AIChatState & AIChatActions>()(
         providerApiKeys: new Map<string, boolean>(),
         apiKeyModalState: { isOpen: false, providerId: null },
         dynamicModels: {},
+        copilotAuthStatus: {
+          isAuthenticated: false,
+          userLogin: null,
+        },
 
         mentionState: {
           active: false,
@@ -549,6 +553,49 @@ export const useAIChatStore = create<AIChatState & AIChatActions>()(
           set((state) => {
             state.dynamicModels[providerId] = models;
           }),
+
+        // Copilot auth actions
+        checkCopilotAuth: async () => {
+          try {
+            const { getCopilotAuthStatus } = await import(
+              "@/features/ai/services/ai-token-service"
+            );
+            const status = await getCopilotAuthStatus();
+            set((state) => {
+              state.copilotAuthStatus = {
+                isAuthenticated: status.isAuthenticated,
+                userLogin: status.userLogin || null,
+              };
+            });
+          } catch {
+            set((state) => {
+              state.copilotAuthStatus = {
+                isAuthenticated: false,
+                userLogin: null,
+              };
+            });
+          }
+        },
+        setCopilotAuthStatus: (status) =>
+          set((state) => {
+            state.copilotAuthStatus = status;
+          }),
+        copilotLogout: async () => {
+          try {
+            const { copilotLogout } = await import(
+              "@/features/ai/services/ai-token-service"
+            );
+            await copilotLogout();
+            set((state) => {
+              state.copilotAuthStatus = {
+                isAuthenticated: false,
+                userLogin: null,
+              };
+            });
+          } catch (error) {
+            console.error("Failed to logout from Copilot:", error);
+          }
+        },
 
         // Mention actions
         showMention: (position, search, startIndex) =>

--- a/src/features/ai/store/types.ts
+++ b/src/features/ai/store/types.ts
@@ -63,6 +63,12 @@ export interface AIChatState {
   // Dynamic models state
   dynamicModels: Record<string, ProviderModel[]>;
 
+  // Copilot auth state
+  copilotAuthStatus: {
+    isAuthenticated: boolean;
+    userLogin: string | null;
+  };
+
   // Mention state
   mentionState: {
     active: boolean;
@@ -151,6 +157,11 @@ export interface AIChatActions {
 
   // Dynamic models actions
   setDynamicModels: (providerId: string, models: ProviderModel[]) => void;
+
+  // Copilot auth actions
+  checkCopilotAuth: () => Promise<void>;
+  setCopilotAuthStatus: (status: { isAuthenticated: boolean; userLogin: string | null }) => void;
+  copilotLogout: () => Promise<void>;
 
   // Mention actions
   showMention: (position: InlineDropdownPosition, search: string, startIndex: number) => void;

--- a/src/features/ai/types/providers.ts
+++ b/src/features/ai/types/providers.ts
@@ -328,6 +328,14 @@ export const AI_PROVIDERS: ModelProvider[] = [
     requiresApiKey: false,
     models: [],
   },
+  {
+    id: "copilot",
+    name: "GitHub Copilot",
+    apiUrl: "https://api.githubcopilot.com/chat/completions",
+    requiresApiKey: false,
+    requiresAuth: true,
+    models: [],
+  },
 ];
 
 // Get all API providers (no longer includes Claude Code since it's now an agent)

--- a/src/features/settings/components/tabs/ai-settings.tsx
+++ b/src/features/settings/components/tabs/ai-settings.tsx
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
-import { AlertCircle, CheckCircle, Globe, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
+import { AlertCircle, CheckCircle, Globe, LogIn, LogOut, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { CopilotAuthModal } from "@/features/ai/components/copilot-auth-modal";
 import { ProviderModelSelector } from "@/features/ai/components/selectors/provider-model-selector";
 import { useAIChatStore } from "@/features/ai/store/store";
 import type { AgentConfig, SessionConfigOption, SessionMode } from "@/features/ai/types/acp";
@@ -8,7 +9,6 @@ import { getAvailableProviders, updateAgentStatus } from "@/features/ai/types/pr
 import { useToast } from "@/features/layout/contexts/toast-context";
 import { getDefaultSetting, useSettingsStore } from "@/features/settings/store";
 import { useAuthStore } from "@/features/window/stores/auth-store";
-import Badge from "@/ui/badge";
 import { Button } from "@/ui/button";
 import Input from "@/ui/input";
 import Section, { SETTINGS_CONTROL_WIDTHS, SettingRow } from "../settings-section";
@@ -53,6 +53,11 @@ export const AISettings = () => {
   const [autocompleteModels, setAutocompleteModels] = useState(DEFAULT_AUTOCOMPLETE_MODELS);
   const [isLoadingAutocompleteModels, setIsLoadingAutocompleteModels] = useState(false);
   const [autocompleteModelError, setAutocompleteModelError] = useState<string | null>(null);
+  const [copilotAuthModalOpen, setCopilotAuthModalOpen] = useState(false);
+
+  const copilotAuthStatus = useAIChatStore((state) => state.copilotAuthStatus);
+  const checkCopilotAuth = useAIChatStore((state) => state.checkCopilotAuth);
+  const copilotLogoutAction = useAIChatStore((state) => state.copilotLogout);
 
   // Ollama URL state
   const [ollamaUrl, setOllamaUrl] = useState(settings.ollamaBaseUrl || DEFAULT_OLLAMA_BASE_URL);
@@ -69,6 +74,7 @@ export const AISettings = () => {
       }
     };
     detectAgents();
+    void checkCopilotAuth();
   }, []);
 
   useEffect(() => {
@@ -240,15 +246,52 @@ export const AISettings = () => {
             <SettingRow
               key={provider.id}
               label={provider.name}
-              description="Requires OAuth authentication"
+              description={
+                provider.id === "copilot" && copilotAuthStatus.isAuthenticated
+                  ? copilotAuthStatus.userLogin
+                    ? `Connected as @${copilotAuthStatus.userLogin}`
+                    : "Connected"
+                  : "Requires OAuth authentication"
+              }
             >
-              <Badge variant="default" size="default">
-                Coming Soon
-              </Badge>
+              {provider.id === "copilot" && copilotAuthStatus.isAuthenticated ? (
+                <div className="flex items-center gap-2">
+                  <CheckCircle className="size-3.5 text-success" />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    onClick={async () => {
+                      await copilotLogoutAction();
+                    }}
+                    className="gap-1 text-text-lighter hover:text-error"
+                  >
+                    <LogOut />
+                    Sign Out
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="xs"
+                  onClick={() => setCopilotAuthModalOpen(true)}
+                  className="gap-1"
+                >
+                  <LogIn />
+                  Sign In
+                </Button>
+              )}
             </SettingRow>
           ))}
         </Section>
       )}
+
+      <CopilotAuthModal
+        isOpen={copilotAuthModalOpen}
+        onClose={() => setCopilotAuthModalOpen(false)}
+        onAuthComplete={() => void checkCopilotAuth()}
+      />
 
       {availableModes.length > 0 && (
         <Section title="Agent Defaults">


### PR DESCRIPTION
Implements GitHub Copilot as an AI provider using OAuth device flow authentication (closes #573).

- OAuth device flow in Rust backend with 5 Tauri commands for start/poll/status/token/logout
- Two-step token chain: GitHub OAuth token (keychain) → Copilot API token (in-memory cache with 5-min expiry buffer)
- CopilotProvider with async header building and dynamic model fetching from the Copilot API
- CopilotAuthModal UI for device code flow with copy-to-clipboard, countdown timer, and polling
- Settings page replaces 'Coming Soon' badge with real Sign In/Connected as UI
- Provider model selector shows Authenticate/Sign Out buttons for Copilot
- CopilotIcon added to provider icon set
- Optional buildHeadersAsync() method on AIProvider interface for providers needing async token refresh
- Copilot uses tauriFetch to avoid CORS restrictions