### PR TITLE
Add Ollama Cloud support with Bearer token auth

### DIFF
--- a/src/features/ai/services/ai-chat-service.ts
+++ b/src/features/ai/services/ai-chat-service.ts
@@ -7,8 +7,10 @@ import { AGENT_OPTIONS, type AgentType } from "@/features/ai/types/ai-chat";
 import type { AIMessage } from "@/features/ai/types/messages";
 import { getModelById, getProviderById } from "@/features/ai/types/providers";
 import { getProvider } from "@/features/ai/services/providers/ai-provider-registry";
+import { isOllamaCloudUrl } from "@/features/ai/services/providers/ollama-provider";
 import { processStreamingResponse } from "@/utils/stream-utils";
 import { getProviderApiToken } from "@/features/ai/services/ai-token-service";
+import { useSettingsStore } from "@/features/settings/store";
 import { AcpStreamHandler } from "./acp-stream-handler";
 import { buildContextPrompt, buildSystemPrompt } from "../utils/ai-context-builder";
 
@@ -87,6 +89,15 @@ export const getChatCompletionStream = async (
     const apiKey = await getProviderApiToken(providerId);
     if (!apiKey && provider.requiresApiKey) {
       throw new Error(`${provider.name} API key not found`);
+    }
+
+    // Ollama Cloud requires auth even though the provider config marks the
+    // key as optional (since local Ollama doesn't need one).
+    if (providerId === "ollama" && !apiKey) {
+      const ollamaBaseUrl = useSettingsStore.getState().settings.ollamaBaseUrl;
+      if (ollamaBaseUrl && isOllamaCloudUrl(ollamaBaseUrl)) {
+        throw new Error("Ollama Cloud requires an API key. Add one in Settings → AI → Ollama.");
+      }
     }
 
     const contextPrompt = buildContextPrompt(context);

--- a/src/features/ai/services/providers/ai-provider-registry.ts
+++ b/src/features/ai/services/providers/ai-provider-registry.ts
@@ -71,12 +71,18 @@ export function getProvider(providerId: string): AIProvider | undefined {
   return providers.get(providerId);
 }
 
-export function setOllamaBaseUrl(baseUrl: string): void {
+function getOllamaProvider(): OllamaProvider | undefined {
   if (providers.size === 0) {
     initializeProviders();
   }
   const ollama = providers.get("ollama");
-  if (ollama instanceof OllamaProvider) {
-    ollama.setBaseUrl(baseUrl);
-  }
+  return ollama instanceof OllamaProvider ? ollama : undefined;
+}
+
+export function setOllamaBaseUrl(baseUrl: string): void {
+  getOllamaProvider()?.setBaseUrl(baseUrl);
+}
+
+export function setOllamaApiKey(apiKey: string | null): void {
+  getOllamaProvider()?.setApiKey(apiKey);
 }

--- a/src/features/ai/services/providers/ollama-provider.ts
+++ b/src/features/ai/services/providers/ollama-provider.ts
@@ -2,11 +2,33 @@ import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import type { ProviderModel } from "./ai-provider-interface";
 import { AIProvider, type ProviderHeaders, type StreamRequest } from "./ai-provider-interface";
 
-const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
-const OLLAMA_TIMEOUT_MS = 3000;
+/**
+ * Ollama provider.
+ *
+ * Supports both local Ollama servers (e.g. `http://localhost:11434`) and
+ * Ollama Cloud (`https://ollama.com`). For cloud, an API key is required and
+ * is sent as a Bearer token. The OpenAI-compatible endpoints (`/v1/*`) are
+ * used for chat completions since they match the streaming format the rest
+ * of the app already parses; model discovery uses the native `/api/tags`
+ * endpoint since that's what Ollama exposes for listing installed models
+ * (and remote models on cloud).
+ *
+ * Docs:
+ * - https://docs.ollama.com/api/introduction
+ * - https://docs.ollama.com/cloud
+ */
+
+export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+export const OLLAMA_CLOUD_BASE_URL = "https://ollama.com";
+
+const OLLAMA_TIMEOUT_MS = 5000;
 
 type OllamaTagsResponse = {
-  models?: Array<{ name?: string }>;
+  models?: Array<{
+    name?: string;
+    model?: string;
+    details?: { parameter_size?: string };
+  }>;
 };
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs = OLLAMA_TIMEOUT_MS): Promise<T> {
@@ -29,17 +51,51 @@ export function normalizeOllamaBaseUrl(url: string): string {
   return url.replace(/\/+$/, "") || DEFAULT_OLLAMA_BASE_URL;
 }
 
-async function fetchOllamaTags(baseUrl: string) {
+/**
+ * Heuristic: is this URL pointing at Ollama Cloud (which requires auth)?
+ *
+ * We only treat `ollama.com` hosts as cloud; everything else (localhost,
+ * LAN IPs, custom gateways) is considered self-hosted and auth is optional.
+ */
+export function isOllamaCloudUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === "ollama.com" || hostname.endsWith(".ollama.com");
+  } catch {
+    return false;
+  }
+}
+
+function buildAuthHeaders(apiKey?: string | null): ProviderHeaders {
+  const headers: ProviderHeaders = {
+    "Content-Type": "application/json",
+  };
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
+
+async function fetchOllamaTags(baseUrl: string, apiKey?: string | null) {
   return withTimeout(
     tauriFetch(`${normalizeOllamaBaseUrl(baseUrl)}/api/tags`, {
       method: "GET",
+      headers: buildAuthHeaders(apiKey),
     }),
   );
 }
 
-export async function checkOllamaConnection(baseUrl: string): Promise<boolean> {
+/**
+ * Ping `/api/tags` and return whether the server responded OK. Optionally
+ * sends an API key for Ollama Cloud. Returns false on any network or auth
+ * error so callers can surface a simple "connected / not connected" state.
+ */
+export async function checkOllamaConnection(
+  baseUrl: string,
+  apiKey?: string | null,
+): Promise<boolean> {
   try {
-    const response = await fetchOllamaTags(baseUrl);
+    const response = await fetchOllamaTags(baseUrl, apiKey);
     return response.ok;
   } catch {
     return false;
@@ -48,8 +104,9 @@ export async function checkOllamaConnection(baseUrl: string): Promise<boolean> {
 
 export class OllamaProvider extends AIProvider {
   private baseUrl: string = DEFAULT_OLLAMA_BASE_URL;
+  private apiKey: string | null = null;
 
-  setBaseUrl(url: string) {
+  setBaseUrl(url: string): void {
     this.baseUrl = normalizeOllamaBaseUrl(url);
   }
 
@@ -57,10 +114,21 @@ export class OllamaProvider extends AIProvider {
     return this.baseUrl;
   }
 
-  buildHeaders(): ProviderHeaders {
-    return {
-      "Content-Type": "application/json",
-    };
+  setApiKey(key: string | null): void {
+    this.apiKey = key && key.length > 0 ? key : null;
+  }
+
+  getApiKey(): string | null {
+    return this.apiKey;
+  }
+
+  /**
+   * Accepts the API key either from the stream request (preferred — that's
+   * the key fetched from secure storage) or falls back to the one stashed
+   * on the instance (used by non-streaming calls like `getModels`).
+   */
+  buildHeaders(apiKey?: string): ProviderHeaders {
+    return buildAuthHeaders(apiKey ?? this.apiKey);
   }
 
   buildPayload(request: StreamRequest) {
@@ -73,8 +141,11 @@ export class OllamaProvider extends AIProvider {
     };
   }
 
-  async validateApiKey(): Promise<boolean> {
-    return true;
+  async validateApiKey(apiKey: string): Promise<boolean> {
+    // If the current base URL is local, any key is effectively valid — but
+    // users only enter a key for cloud, so validate against cloud.
+    const target = isOllamaCloudUrl(this.baseUrl) ? this.baseUrl : OLLAMA_CLOUD_BASE_URL;
+    return checkOllamaConnection(target, apiKey);
   }
 
   buildUrl(): string {
@@ -83,19 +154,22 @@ export class OllamaProvider extends AIProvider {
 
   async getModels(): Promise<ProviderModel[]> {
     try {
-      const response = await fetchOllamaTags(this.baseUrl);
+      const response = await fetchOllamaTags(this.baseUrl, this.apiKey);
       if (!response.ok) return [];
 
       const data = (await response.json()) as OllamaTagsResponse;
-      return (data.models || [])
-        .filter(
-          (model): model is { name: string } => typeof model.name === "string" && !!model.name,
-        )
-        .map((model) => ({
-          id: model.name,
-          name: model.name,
+      const models: ProviderModel[] = [];
+      for (const model of data.models || []) {
+        const id = model.name || model.model;
+        if (!id) continue;
+        const paramSize = model.details?.parameter_size;
+        models.push({
+          id,
+          name: paramSize ? `${id} (${paramSize})` : id,
           maxTokens: 4096,
-        }));
+        });
+      }
+      return models;
     } catch {
       return [];
     }

--- a/src/features/ai/types/providers.ts
+++ b/src/features/ai/types/providers.ts
@@ -485,7 +485,7 @@ export const AI_PROVIDERS: ModelProvider[] = [
   },
   {
     id: "ollama",
-    name: "Ollama (Local)",
+    name: "Ollama",
     apiUrl: "http://localhost:11434/v1/chat/completions",
     requiresApiKey: false,
     models: [],

--- a/src/features/settings/components/tabs/ai-settings.tsx
+++ b/src/features/settings/components/tabs/ai-settings.tsx
@@ -1,5 +1,16 @@
 import { invoke } from "@tauri-apps/api/core";
-import { AlertCircle, CheckCircle, Globe, RefreshCw, RotateCcw, Trash2 } from "lucide-react";
+import {
+  AlertCircle,
+  CheckCircle,
+  Cloud,
+  ExternalLink,
+  Globe,
+  Key,
+  Laptop,
+  RefreshCw,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ProviderModelSelector } from "@/features/ai/components/selectors/provider-model-selector";
 import { useAIChatStore } from "@/features/ai/store/store";
@@ -16,10 +27,21 @@ import Select from "@/ui/select";
 import Switch from "@/ui/switch";
 import { fetchAutocompleteModels } from "@/features/editor/services/editor-autocomplete-service";
 import { cn } from "@/utils/cn";
-import { setOllamaBaseUrl } from "@/features/ai/services/providers/ai-provider-registry";
-import { checkOllamaConnection } from "@/features/ai/services/providers/ollama-provider";
-
-const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+import {
+  setOllamaApiKey,
+  setOllamaBaseUrl,
+} from "@/features/ai/services/providers/ai-provider-registry";
+import {
+  DEFAULT_OLLAMA_BASE_URL,
+  OLLAMA_CLOUD_BASE_URL,
+  checkOllamaConnection,
+  isOllamaCloudUrl,
+} from "@/features/ai/services/providers/ollama-provider";
+import {
+  getProviderApiToken,
+  removeProviderApiToken,
+  storeProviderApiToken,
+} from "@/features/ai/services/ai-token-service";
 const DEFAULT_AUTOCOMPLETE_MODEL_ID = "mistralai/devstral-small";
 const NO_DEFAULT_SESSION_MODE = "__none__";
 
@@ -59,6 +81,14 @@ export const AISettings = () => {
   const [ollamaStatus, setOllamaStatus] = useState<"idle" | "checking" | "ok" | "error">("idle");
   const ollamaDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
+  // Ollama API key state (used for Ollama Cloud; optional for local)
+  const [ollamaApiKeyInput, setOllamaApiKeyInput] = useState("");
+  const [hasStoredOllamaKey, setHasStoredOllamaKey] = useState(false);
+  const [isSavingOllamaKey, setIsSavingOllamaKey] = useState(false);
+
+  const isOllamaCloud = isOllamaCloudUrl(ollamaUrl);
+  const needsApiKey = isOllamaCloud;
+
   useEffect(() => {
     const detectAgents = async () => {
       try {
@@ -81,17 +111,31 @@ export const AISettings = () => {
     return unsubscribe;
   }, []);
 
-  // Sync Ollama base URL on mount
+  // Sync Ollama base URL + API key on mount
   useEffect(() => {
     const url = settings.ollamaBaseUrl || DEFAULT_OLLAMA_BASE_URL;
     setOllamaBaseUrl(url);
+    void (async () => {
+      const token = await getProviderApiToken("ollama");
+      setHasStoredOllamaKey(!!token);
+      setOllamaApiKey(token);
+    })();
   }, []);
 
-  const validateOllamaConnection = useCallback(async (url: string) => {
-    setOllamaStatus("checking");
-    const ok = await checkOllamaConnection(url);
-    setOllamaStatus(ok ? "ok" : "error");
-  }, []);
+  const validateOllamaConnection = useCallback(
+    async (url: string, apiKey?: string | null) => {
+      setOllamaStatus("checking");
+      const keyToUse =
+        apiKey !== undefined
+          ? apiKey
+          : hasStoredOllamaKey
+            ? await getProviderApiToken("ollama")
+            : null;
+      const ok = await checkOllamaConnection(url, keyToUse);
+      setOllamaStatus(ok ? "ok" : "error");
+    },
+    [hasStoredOllamaKey],
+  );
 
   const handleOllamaUrlChange = (value: string) => {
     setOllamaUrl(value);
@@ -102,7 +146,7 @@ export const AISettings = () => {
       const trimmed = value.replace(/\/+$/, "") || DEFAULT_OLLAMA_BASE_URL;
       updateSetting("ollamaBaseUrl", trimmed);
       setOllamaBaseUrl(trimmed);
-      validateOllamaConnection(trimmed);
+      void validateOllamaConnection(trimmed);
     }, 600);
   };
 
@@ -110,7 +154,45 @@ export const AISettings = () => {
     setOllamaUrl(DEFAULT_OLLAMA_BASE_URL);
     updateSetting("ollamaBaseUrl", DEFAULT_OLLAMA_BASE_URL);
     setOllamaBaseUrl(DEFAULT_OLLAMA_BASE_URL);
-    validateOllamaConnection(DEFAULT_OLLAMA_BASE_URL);
+    void validateOllamaConnection(DEFAULT_OLLAMA_BASE_URL);
+  };
+
+  const handleUseOllamaCloud = () => {
+    setOllamaUrl(OLLAMA_CLOUD_BASE_URL);
+    updateSetting("ollamaBaseUrl", OLLAMA_CLOUD_BASE_URL);
+    setOllamaBaseUrl(OLLAMA_CLOUD_BASE_URL);
+    void validateOllamaConnection(OLLAMA_CLOUD_BASE_URL);
+  };
+
+  const handleSaveOllamaApiKey = async () => {
+    const trimmed = ollamaApiKeyInput.trim();
+    if (!trimmed) return;
+    setIsSavingOllamaKey(true);
+    try {
+      await storeProviderApiToken("ollama", trimmed);
+      setOllamaApiKey(trimmed);
+      setHasStoredOllamaKey(true);
+      setOllamaApiKeyInput("");
+      showToast({ message: "Ollama API key saved", type: "success" });
+      void validateOllamaConnection(ollamaUrl, trimmed);
+    } catch {
+      showToast({ message: "Failed to save Ollama API key", type: "error" });
+    } finally {
+      setIsSavingOllamaKey(false);
+    }
+  };
+
+  const handleRemoveOllamaApiKey = async () => {
+    try {
+      await removeProviderApiToken("ollama");
+      setOllamaApiKey(null);
+      setHasStoredOllamaKey(false);
+      setOllamaApiKeyInput("");
+      showToast({ message: "Ollama API key removed", type: "success" });
+      void validateOllamaConnection(ollamaUrl, null);
+    } catch {
+      showToast({ message: "Failed to remove Ollama API key", type: "error" });
+    }
   };
 
   const providers = getAvailableProviders();
@@ -190,6 +272,30 @@ export const AISettings = () => {
 
       {(isOllamaSelected || settings.ollamaBaseUrl !== DEFAULT_OLLAMA_BASE_URL) && (
         <Section title="Ollama">
+          <SettingRow label="Mode" description="Run Ollama locally or use Ollama Cloud">
+            <div className="flex items-center gap-1.5">
+              <Button
+                type="button"
+                variant={isOllamaCloud ? "secondary" : "default"}
+                size="xs"
+                onClick={handleResetOllamaUrl}
+                className="gap-1.5"
+              >
+                <Laptop />
+                Local
+              </Button>
+              <Button
+                type="button"
+                variant={isOllamaCloud ? "default" : "secondary"}
+                size="xs"
+                onClick={handleUseOllamaCloud}
+                className="gap-1.5"
+              >
+                <Cloud />
+                Cloud
+              </Button>
+            </div>
+          </SettingRow>
           <SettingRow
             label="Endpoint"
             description="Base URL for Ollama API (local, LAN, or cloud)"
@@ -225,10 +331,74 @@ export const AISettings = () => {
               )}
             </div>
           </SettingRow>
+          <SettingRow
+            label="API Key"
+            description={
+              needsApiKey
+                ? "Required for Ollama Cloud — create one at ollama.com/settings/keys"
+                : "Optional — only needed if your Ollama server requires authentication"
+            }
+          >
+            <div className="flex items-center gap-1.5">
+              <Input
+                type="password"
+                value={ollamaApiKeyInput}
+                onChange={(e) => setOllamaApiKeyInput(e.target.value)}
+                placeholder={hasStoredOllamaKey ? "••••••••  (saved)" : "ollama-…"}
+                spellCheck={false}
+                leftIcon={Key}
+                className={cn("w-56", needsApiKey && !hasStoredOllamaKey && "border-warning/60")}
+                autoComplete="off"
+                disabled={isSavingOllamaKey}
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                size="xs"
+                onClick={handleSaveOllamaApiKey}
+                disabled={!ollamaApiKeyInput.trim() || isSavingOllamaKey}
+              >
+                {isSavingOllamaKey ? "Saving…" : "Save"}
+              </Button>
+              {hasStoredOllamaKey && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={handleRemoveOllamaApiKey}
+                  title="Remove saved API key"
+                  aria-label="Remove Ollama API key"
+                  className="text-error hover:bg-error/10"
+                >
+                  <Trash2 />
+                </Button>
+              )}
+            </div>
+          </SettingRow>
+          {needsApiKey && !hasStoredOllamaKey && (
+            <div className="ui-font ui-text-sm flex items-center gap-1.5 px-1 text-text-lighter">
+              <AlertCircle className="shrink-0 text-warning" />
+              <span>
+                Ollama Cloud requires an API key.{" "}
+                <a
+                  href="https://ollama.com/settings/keys"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-link hover:underline"
+                >
+                  Get one here <ExternalLink className="size-3" />
+                </a>
+              </span>
+            </div>
+          )}
           {ollamaStatus === "error" && (
             <div className="ui-font ui-text-sm flex items-center gap-1.5 px-1 text-error">
               <AlertCircle className="shrink-0" />
-              <span>Could not connect. Check that Ollama is running at this address.</span>
+              <span>
+                {isOllamaCloud
+                  ? "Could not reach Ollama Cloud. Verify your API key and internet connection."
+                  : "Could not connect. Check that Ollama is running at this address."}
+              </span>
             </div>
           )}
         </Section>

--- a/src/features/settings/config/search-index.ts
+++ b/src/features/settings/config/search-index.ts
@@ -447,6 +447,14 @@ export const settingsSearchIndex: SettingSearchRecord[] = [
     keywords: ["ollama", "endpoint", "url", "local", "lan", "cloud", "host", "port"],
   },
   {
+    id: "ai-ollama-api-key",
+    tab: "ai",
+    section: "Ollama",
+    label: "Ollama API Key",
+    description: "Bearer token for Ollama Cloud (optional for local servers)",
+    keywords: ["ollama", "api", "key", "token", "auth", "cloud", "bearer"],
+  },
+  {
     id: "ai-default-session-mode",
     tab: "ai",
     section: "Agent Defaults",

--- a/src/features/settings/lib/settings-effects.ts
+++ b/src/features/settings/lib/settings-effects.ts
@@ -129,6 +129,20 @@ export function syncOllamaBaseUrl(baseUrl: string) {
   );
 }
 
+/**
+ * Pushes the Ollama API key (stored in Tauri's secure storage) into the
+ * singleton provider instance so `getModels`, connection checks, and other
+ * non-streaming calls can authenticate with Ollama Cloud.
+ */
+export async function syncOllamaApiKey() {
+  const [{ setOllamaApiKey }, { getProviderApiToken }] = await Promise.all([
+    import("@/features/ai/services/providers/ai-provider-registry"),
+    import("@/features/ai/services/ai-token-service"),
+  ]);
+  const token = await getProviderApiToken("ollama");
+  setOllamaApiKey(token);
+}
+
 export function applySettingsSideEffects(settings: Settings) {
   cacheFontSettings(settings);
   void applyTheme(getEffectiveTheme(settings));
@@ -138,6 +152,7 @@ export function applySettingsSideEffects(settings: Settings) {
     stopSystemThemeSync();
   }
   syncOllamaBaseUrl(settings.ollamaBaseUrl);
+  void syncOllamaApiKey();
 }
 
 export function applySettingSideEffect<K extends keyof Settings>(


### PR DESCRIPTION
## Summary

Extends the Ollama provider so it works against both local Ollama servers and [Ollama Cloud](https://ollama.com). Previously the provider hardcoded a no-auth local endpoint, so pointing it at `https://ollama.com` silently failed.

- Refactor `OllamaProvider` to hold an optional API key and attach `Authorization: Bearer …` to streaming requests, model discovery (`/api/tags`), and connection checks.
- Add `isOllamaCloudUrl` / `OLLAMA_CLOUD_BASE_URL` helpers; reuse them across `ai-settings`, `ai-chat-service`, and the provider itself.
- AI Settings → Ollama: new Local/Cloud preset buttons and a password-style API key field wired through the existing secure-token service (`storeProviderApiToken` / `getProviderApiToken` / `removeProviderApiToken`).
- Sync the stored key into the provider singleton at startup via `settings-effects` so `getModels` and the connection indicator work on first load.
- Chat stream guard: if the endpoint is cloud but no key is stored, fail fast with a message that points back to settings.
- `getModels` now appends the parameter size (e.g. `llama3 (8B)`) when the server reports it.
- Rename provider label from \"Ollama (Local)\" to \"Ollama\" since it covers both modes.

Docs referenced: <https://docs.ollama.com/api/introduction>, <https://docs.ollama.com/cloud>.

## Test plan

- [ ] Local Ollama: open Settings → AI → Ollama, status indicator goes green, models populate from `/api/tags`, chat streams.
- [ ] Click \"Cloud\": URL switches to `https://ollama.com`, warning shows until a key is entered.
- [ ] Paste an Ollama Cloud key, Save → toast confirms, status turns green, cloud model list loads, chat streams.
- [ ] Remove key → status flips to error, clear remediation text shown.
- [ ] Switch back to Local → everything works without the key.
- [ ] Search Settings for \"ollama api key\" → new entry appears.

Fixes #372 