### PR TITLE
Integrate fff.nvim's search engine into global search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -221,6 +221,12 @@ checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -548,6 +554,7 @@ dependencies = [
  "athas-ai",
  "athas-database",
  "athas-extensions",
+ "athas-fff-search",
  "athas-github",
  "athas-lsp",
  "athas-project",
@@ -668,6 +675,16 @@ dependencies = [
  "sha256",
  "tar",
  "tauri",
+]
+
+[[package]]
+name = "athas-fff-search"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fff-search",
+ "log",
+ "serde",
 ]
 
 [[package]]
@@ -850,6 +867,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bindet"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5afee99ef5f7527f3944f2bf4f5d443749fa47d43eb1d4f83a36e839be7900a3"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +906,20 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -981,6 +1027,16 @@ dependencies = [
  "serde_json",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1314,6 +1370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1483,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1840,6 +1911,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf 0.11.3",
+]
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2212,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "fff-grep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bac75b4c81cf5efbee66d95760ff91dc6f1a105eea7c0477640512d88d9da8"
+dependencies = [
+ "bstr",
+ "memchr",
+]
+
+[[package]]
+name = "fff-query-parser"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b495c4ada3a9e3b2dc8585a8811c2beba7a18556ffa7f3212cc22ad9bb66b1"
+
+[[package]]
+name = "fff-search"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90f3f8bcbc5ad57de86ad785e75335953d89d7613c79c7d306957a6a0550b83"
+dependencies = [
+ "ahash 0.8.12",
+ "aho-corasick",
+ "bindet",
+ "blake3",
+ "chrono",
+ "dirs 5.0.1",
+ "dunce",
+ "fff-grep",
+ "fff-query-parser",
+ "git2",
+ "glidesort",
+ "globset",
+ "heed",
+ "ignore",
+ "memchr",
+ "memmap2",
+ "neo_frizbee",
+ "notify",
+ "notify-debouncer-full",
+ "once_cell",
+ "parking_lot",
+ "pathdiff",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "smartstring",
+ "thiserror 2.0.17",
+ "toml 0.8.2",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2276,15 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2672,10 +2818,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "glidesort"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e102e6eb644d3e0b186fc161e4460417880a0a0b87d235f2e5b8fb30f2e9e0"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -2836,6 +3001,44 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "heed"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad82d6598ccf1dac15c8b758a1bd282b755b6776be600429176757190a1b0202"
+dependencies = [
+ "bitflags 2.10.0",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3203,6 +3406,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,6 +3554,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3754,6 +3982,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "lmdb-master-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaeb9bd22e73bd1babffff614994b341e9b2008de7bb73bf1f7e9154f1978f8b"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,6 +4136,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -4154,6 +4402,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "neo_frizbee"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34a8a11f48357cecd5ada0751f1490d8da4dd935e595d34cc2727567d5288ead"
+dependencies = [
+ "itertools 0.14.0",
+ "raw-cpuid",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4218,6 +4476,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-debouncer-full"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
 name = "notify-debouncer-mini"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4234,6 +4505,15 @@ name = "notify-types"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nucleo"
@@ -4844,6 +5124,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5569,6 +5859,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5607,7 +5906,7 @@ dependencies = [
  "combine",
  "futures",
  "futures-util",
- "itertools",
+ "itertools 0.13.0",
  "itoa",
  "num-bigint",
  "percent-encoding",
@@ -6348,7 +6647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6365,7 +6664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -6380,6 +6679,15 @@ dependencies = [
  "hex",
  "sha2",
  "tokio",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -6501,6 +6809,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "serde",
+ "static_assertions",
+ "version_check",
 ]
 
 [[package]]
@@ -6903,6 +7223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
 ]
 
 [[package]]
@@ -7599,6 +7928,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7919,6 +8257,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7936,6 +8286,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -8204,6 +8584,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -9529,7 +9915,7 @@ dependencies = [
  "aes",
  "arbitrary",
  "bzip2",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/terminal",
   "crates/ai",
   "crates/github",
+  "crates/fff-search",
 ]
 resolver = "2"
 

--- a/crates/fff-search/Cargo.toml
+++ b/crates/fff-search/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "athas-fff-search"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+fff-search = "0.5"

--- a/crates/fff-search/src/lib.rs
+++ b/crates/fff-search/src/lib.rs
@@ -1,0 +1,105 @@
+use anyhow::{Context, Result};
+use fff_search::{
+   FilePicker, FilePickerOptions, FrecencyTracker, FuzzySearchOptions, PaginationArgs, QueryParser,
+   SharedFrecency, SharedPicker,
+};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub struct FffSearch {
+   picker: SharedPicker,
+   frecency: SharedFrecency,
+   db_path: PathBuf,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct FffSearchHit {
+   pub path: String,
+   pub name: String,
+   pub relative_path: String,
+   pub score: i32,
+}
+
+impl FffSearch {
+   pub fn new(frecency_db_path: impl Into<PathBuf>) -> Result<Self> {
+      let db_path = frecency_db_path.into();
+      if let Some(parent) = db_path.parent() {
+         std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating frecency db dir {:?}", parent))?;
+      }
+
+      let picker = SharedPicker::default();
+      let frecency = SharedFrecency::default();
+
+      let tracker = FrecencyTracker::new(&db_path, false)
+         .with_context(|| format!("opening frecency db at {:?}", db_path))?;
+      frecency
+         .init(tracker)
+         .context("initializing shared frecency")?;
+
+      Ok(Self {
+         picker,
+         frecency,
+         db_path,
+      })
+   }
+
+   pub fn set_workspace(&self, base_path: &Path) -> Result<()> {
+      let options = FilePickerOptions {
+         base_path: base_path.to_string_lossy().into_owned(),
+         watch: true,
+         ..Default::default()
+      };
+
+      FilePicker::new_with_shared_state(self.picker.clone(), self.frecency.clone(), options)
+         .context("initializing fff FilePicker")?;
+      Ok(())
+   }
+
+   pub fn search(&self, query: &str, limit: usize) -> Result<Vec<FffSearchHit>> {
+      let guard = self.picker.read().context("reading picker")?;
+      let Some(picker) = guard.as_ref() else {
+         return Ok(Vec::new());
+      };
+
+      let parser = QueryParser::default();
+      let parsed = parser.parse(query);
+
+      let opts = FuzzySearchOptions {
+         pagination: PaginationArgs {
+            offset: 0,
+            limit: limit.max(1),
+         },
+         ..Default::default()
+      };
+
+      let result = FilePicker::fuzzy_search(picker.get_files(), &parsed, None, opts);
+
+      let hits: Vec<FffSearchHit> = result
+         .items
+         .iter()
+         .zip(result.scores.iter())
+         .map(|(item, score)| FffSearchHit {
+            path: item.path.to_string_lossy().into_owned(),
+            name: item.file_name.clone(),
+            relative_path: item.relative_path.clone(),
+            score: score.total,
+         })
+         .collect();
+
+      Ok(hits)
+   }
+
+   pub fn track_access(&self, path: &Path) -> Result<()> {
+      let guard = self.frecency.read().context("reading frecency")?;
+      if let Some(tracker) = guard.as_ref() {
+         tracker.track_access(path).context("track_access")?;
+      }
+      Ok(())
+   }
+
+   pub fn db_path(&self) -> &Path {
+      &self.db_path
+   }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ athas-extensions = { path = "../crates/extensions" }
 athas-terminal = { path = "../crates/terminal" }
 athas-ai = { path = "../crates/ai" }
 athas-github = { path = "../crates/github" }
+athas-fff-search = { path = "../crates/fff-search" }
 mimalloc = { version = "0.1", default-features = false }
 log = "0.4.27"
 percent-encoding = "2"

--- a/src-tauri/src/app_setup.rs
+++ b/src-tauri/src/app_setup.rs
@@ -1,5 +1,5 @@
 use crate::{
-   commands::{self, FileClipboard, ThemeCache},
+   commands::{self, FffSearchState, FileClipboard, ThemeCache},
    file_events::TauriFileChangeEmitter,
    menu,
    terminal::ManagedTerminalManager as TerminalManager,
@@ -69,6 +69,7 @@ fn register_managed_state(app: &mut tauri::App<Wry>) {
    app.manage(ThemeCache::new(std::collections::HashMap::new()));
    app.manage(FileClipboard::new(None));
    app.manage(Arc::new(ConnectionManager::new()));
+   app.manage(FffSearchState::new());
 }
 
 fn emit_cli_open_requests(app: &tauri::App<Wry>) {

--- a/src-tauri/src/commands/fuzzy.rs
+++ b/src-tauri/src/commands/fuzzy.rs
@@ -1,8 +1,11 @@
+use athas_fff_search::{FffSearch, FffSearchHit};
 use nucleo_matcher::{
    Config, Matcher, Utf32Str,
    pattern::{Atom, AtomKind, CaseMatching, Normalization},
 };
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager, State};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FuzzyMatchItem {
@@ -196,4 +199,61 @@ pub fn filter_completions(request: CompletionFilterRequest) -> Vec<FilteredCompl
    filtered.truncate(50);
 
    filtered
+}
+
+pub struct FffSearchState(pub std::sync::OnceLock<FffSearch>);
+
+impl FffSearchState {
+   pub fn new() -> Self {
+      Self(std::sync::OnceLock::new())
+   }
+
+   fn get_or_init(&self, app: &AppHandle) -> Result<&FffSearch, String> {
+      if let Some(fff) = self.0.get() {
+         return Ok(fff);
+      }
+
+      let data_dir = app
+         .path()
+         .app_data_dir()
+         .map_err(|e| format!("app_data_dir: {e}"))?;
+      let db_path: PathBuf = data_dir.join("fff-frecency.lmdb");
+      let fff = FffSearch::new(db_path).map_err(|e| format!("fff init: {e}"))?;
+      let _ = self.0.set(fff);
+      Ok(self.0.get().unwrap())
+   }
+}
+
+#[tauri::command]
+pub fn fff_set_workspace(
+   app: AppHandle,
+   state: State<'_, FffSearchState>,
+   base_path: String,
+) -> Result<(), String> {
+   let fff = state.get_or_init(&app)?;
+   fff.set_workspace(std::path::Path::new(&base_path))
+      .map_err(|e| format!("fff set_workspace: {e}"))
+}
+
+#[tauri::command]
+pub fn fff_search_files(
+   app: AppHandle,
+   state: State<'_, FffSearchState>,
+   query: String,
+   limit: Option<usize>,
+) -> Result<Vec<FffSearchHit>, String> {
+   let fff = state.get_or_init(&app)?;
+   fff.search(&query, limit.unwrap_or(100))
+      .map_err(|e| format!("fff search: {e}"))
+}
+
+#[tauri::command]
+pub fn fff_track_access(
+   app: AppHandle,
+   state: State<'_, FffSearchState>,
+   path: String,
+) -> Result<(), String> {
+   let fff = state.get_or_init(&app)?;
+   fff.track_access(std::path::Path::new(&path))
+      .map_err(|e| format!("fff track_access: {e}"))
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -295,6 +295,9 @@ fn main() {
          // Fuzzy matching commands
          fuzzy_match,
          filter_completions,
+         fff_set_workspace,
+         fff_search_files,
+         fff_track_access,
          // Search commands
          search_files_content,
          // EditorConfig commands

--- a/src/features/file-system/controllers/store.ts
+++ b/src/features/file-system/controllers/store.ts
@@ -60,6 +60,7 @@ import {
   isPdfFile,
 } from "./file-utils";
 import { useFileWatcherStore } from "./file-watcher-store";
+import { fffSetWorkspace, fffTrackAccess } from "@/features/global-search/lib/rust-api/search";
 import { getSymlinkInfo, openFolder, readDirectory, renameFile } from "./platform";
 import { useRecentFoldersStore } from "./recent-folders-store";
 import { shouldIgnore, updateDirectoryContents } from "./utils";
@@ -273,6 +274,10 @@ export const useFileSystemStore = createSelectors(
             logWorkspaceOpenStep("start", "setProjectRoot", selected);
             await useFileWatcherStore.getState().setProjectRoot(selected);
             logWorkspaceOpenStep("end", "setProjectRoot", selected, watcherStartedAt);
+
+            fffSetWorkspace(selected).catch((error) => {
+              console.error("[fff] set_workspace failed:", error);
+            });
 
             const gitStatusStartedAt = performance.now();
             logWorkspaceOpenStep("start", "getGitStatus", selected);
@@ -530,6 +535,10 @@ export const useFileSystemStore = createSelectors(
             await useFileWatcherStore.getState().setProjectRoot(path);
             logWorkspaceOpenStep("end", "setProjectRoot", path, watcherStartedAt);
 
+            fffSetWorkspace(path).catch((error) => {
+              console.error("[fff] set_workspace failed:", error);
+            });
+
             const gitStatusStartedAt = performance.now();
             logWorkspaceOpenStep("start", "getGitStatus", path);
             const gitStatus = await getGitStatus(path);
@@ -658,6 +667,12 @@ export const useFileSystemStore = createSelectors(
         if (isDir) {
           await get().toggleFolder(path);
           return;
+        }
+
+        if (!isPreview) {
+          fffTrackAccess(path).catch((error) => {
+            console.error("[fff] track_access failed:", error);
+          });
         }
 
         fileOpenBenchmark.ensureStarted(path, isPreview ? "preview" : "definite");

--- a/src/features/global-search/hooks/use-fff-search.ts
+++ b/src/features/global-search/hooks/use-fff-search.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { fffSearchFiles, type FffSearchHit } from "../lib/rust-api/search";
+import { MAX_RESULTS } from "../constants/limits";
+
+export const useFffSearch = (query: string, enabled: boolean) => {
+  const [hits, setHits] = useState<FffSearchHit[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !query.trim()) {
+      setHits([]);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    fffSearchFiles(query, MAX_RESULTS)
+      .then((results) => {
+        if (cancelled) return;
+        setHits(results);
+        setError(null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("[fff] search failed:", err);
+        setError(String(err));
+        setHits([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [query, enabled]);
+
+  return { hits, error };
+};

--- a/src/features/global-search/hooks/use-file-search.ts
+++ b/src/features/global-search/hooks/use-file-search.ts
@@ -9,9 +9,14 @@ import {
   MAX_RESULTS,
 } from "../constants/limits";
 import type { CategorizedFiles, FileItem } from "../models/types";
+import type { FffSearchHit } from "../lib/rust-api/search";
 import { fuzzyScore } from "../utils/fuzzy-search";
 
-export const useFileSearch = (files: FileItem[], debouncedQuery: string) => {
+export const useFileSearch = (
+  files: FileItem[],
+  debouncedQuery: string,
+  fffHits: FffSearchHit[] | null = null,
+) => {
   const buffers = useBufferStore.use.buffers();
   const activeBufferId = useBufferStore.use.activeBufferId();
   const getRecentFilesOrderedByFrecency = useRecentFilesStore(
@@ -68,40 +73,46 @@ export const useFileSearch = (files: FileItem[], debouncedQuery: string) => {
       };
     }
 
-    // With search query - fuzzy search all files, results are limited at the end
-    const scoredFiles = files
-      .map((file) => {
-        const nameScore = fuzzyScore(file.name, debouncedQuery);
-        const pathScore = fuzzyScore(file.path, debouncedQuery);
-        const score = Math.max(nameScore, pathScore);
-        return { file, score };
-      })
-      .filter(({ score }) => score > 0)
-      .sort((a, b) => {
-        // First sort by score (highest first)
-        if (b.score !== a.score) return b.score - a.score;
+    // With search query: prefer fff Rust results (frecency + git aware) when available
+    const scoredFiles =
+      fffHits && fffHits.length > 0
+        ? fffHits.map((hit) => ({
+            file: { name: hit.name, path: hit.path, isDir: false } as FileItem,
+            score: hit.score,
+          }))
+        : files
+            .map((file) => {
+              const nameScore = fuzzyScore(file.name, debouncedQuery);
+              const pathScore = fuzzyScore(file.path, debouncedQuery);
+              const score = Math.max(nameScore, pathScore);
+              return { file, score };
+            })
+            .filter(({ score }) => score > 0)
+            .sort((a, b) => {
+              // First sort by score (highest first)
+              if (b.score !== a.score) return b.score - a.score;
 
-        // Then prioritize open buffers
-        const aIsOpen = openBufferPaths.has(a.file.path);
-        const bIsOpen = openBufferPaths.has(b.file.path);
-        if (aIsOpen && !bIsOpen) return -1;
-        if (!aIsOpen && bIsOpen) return 1;
+              // Then prioritize open buffers
+              const aIsOpen = openBufferPaths.has(a.file.path);
+              const bIsOpen = openBufferPaths.has(b.file.path);
+              if (aIsOpen && !bIsOpen) return -1;
+              if (!aIsOpen && bIsOpen) return 1;
 
-        // Then prioritize recent files by frecency
-        const aIsRecent = recentFilePaths.has(a.file.path);
-        const bIsRecent = recentFilePaths.has(b.file.path);
-        if (aIsRecent && !bIsRecent) return -1;
-        if (!aIsRecent && bIsRecent) return 1;
+              // Then prioritize recent files by frecency
+              const aIsRecent = recentFilePaths.has(a.file.path);
+              const bIsRecent = recentFilePaths.has(b.file.path);
+              if (aIsRecent && !bIsRecent) return -1;
+              if (!aIsRecent && bIsRecent) return 1;
 
-        if (aIsRecent && bIsRecent) {
-          const aIndex = recentFileIndices.get(a.file.path) ?? Number.MAX_VALUE;
-          const bIndex = recentFileIndices.get(b.file.path) ?? Number.MAX_VALUE;
-          return aIndex - bIndex;
-        }
+              if (aIsRecent && bIsRecent) {
+                const aIndex = recentFileIndices.get(a.file.path) ?? Number.MAX_VALUE;
+                const bIndex = recentFileIndices.get(b.file.path) ?? Number.MAX_VALUE;
+                return aIndex - bIndex;
+              }
 
-        // Finally sort alphabetically
-        return a.file.name.localeCompare(b.file.name);
-      });
+              // Finally sort alphabetically
+              return a.file.name.localeCompare(b.file.name);
+            });
 
     const openBuffers = scoredFiles
       .filter(({ file }) => openBufferPaths.has(file.path))
@@ -125,7 +136,7 @@ export const useFileSearch = (files: FileItem[], debouncedQuery: string) => {
       recentFilesInResults: recent.slice(0, MAX_RESULTS - openBuffers.length),
       otherFiles: others.slice(0, MAX_OTHER_FILES_SHOWN - openBuffers.length - recent.length),
     };
-  }, [files, debouncedQuery, buffers, activeBufferId, recentFiles, activeBuffer]);
+  }, [files, debouncedQuery, buffers, activeBufferId, recentFiles, activeBuffer, fffHits]);
 
   return categorizedFiles;
 };

--- a/src/features/global-search/hooks/use-global-search.ts
+++ b/src/features/global-search/hooks/use-global-search.ts
@@ -5,6 +5,7 @@ import { useFileSystemStore } from "@/features/file-system/controllers/store";
 import { useSettingsStore } from "@/features/settings/store";
 import { useUIState } from "@/features/window/stores/ui-state-store";
 import { PREVIEW_DEBOUNCE_DELAY, SEARCH_DEBOUNCE_DELAY } from "../constants/limits";
+import { useFffSearch } from "./use-fff-search";
 import { useFileLoader } from "./use-file-loader";
 import { useFileSearch } from "./use-file-search";
 import { useKeyboardNavigation } from "./use-keyboard-navigation";
@@ -35,10 +36,14 @@ export const useGlobalSearch = () => {
     rootFolderPath: loaderRootFolder,
   } = useFileLoader(isGlobalSearchVisible);
 
+  // Rust-side fuzzy search with frecency + git ranking (only when visible)
+  const { hits: fffHits } = useFffSearch(debouncedQuery, isGlobalSearchVisible);
+
   // Search and categorize files
   const { openBufferFiles, recentFilesInResults, otherFiles } = useFileSearch(
     files,
     debouncedQuery,
+    fffHits,
   );
 
   // Handle file selection

--- a/src/features/global-search/lib/rust-api/search.ts
+++ b/src/features/global-search/lib/rust-api/search.ts
@@ -23,3 +23,22 @@ export interface SearchFilesRequest {
 export async function searchFilesContent(request: SearchFilesRequest): Promise<FileSearchResult[]> {
   return invoke<FileSearchResult[]>("search_files_content", { request });
 }
+
+export interface FffSearchHit {
+  path: string;
+  name: string;
+  relative_path: string;
+  score: number;
+}
+
+export async function fffSetWorkspace(basePath: string): Promise<void> {
+  return invoke("fff_set_workspace", { basePath });
+}
+
+export async function fffSearchFiles(query: string, limit = 100): Promise<FffSearchHit[]> {
+  return invoke<FffSearchHit[]>("fff_search_files", { query, limit });
+}
+
+export async function fffTrackAccess(path: string): Promise<void> {
+  return invoke("fff_track_access", { path });
+}


### PR DESCRIPTION
## Summary

Global search now uses [fff.nvim](https://github.com/dmtrKovalenko/fff.nvim)'s Rust core (`fff-search` crate) instead of the hand-rolled JS `fuzzyScore` for ranking file-name results.

**What changes for the user:**
- Frequently opened files rise to the top (frecency).
- Modified / staged files get a boost (git-aware scoring).
- Smarter fuzzy matching from the underlying `neo_frizbee` matcher.
- Background file watching keeps the index fresh without re-scanning.

**How it's wired:**
- New `athas-fff-search` workspace crate wraps `FilePicker` + `FrecencyTracker` into a small `FffSearch` handle. The LMDB frecency DB lives under the app data dir.
- Three Tauri commands: `fff_set_workspace`, `fff_search_files`, `fff_track_access`.
- `fff_set_workspace` is called from `handleOpenFolder` / `handleOpenFolderByPath` (non-blocking — the initial scan runs in background).
- `fff_track_access` is called from `handleFileSelect` on definite (non-preview) opens.
- A new `useFffSearch` hook queries the Rust side on debounced query changes; `useFileSearch` prefers these hits when present and falls back to the existing JS scorer while the picker is still scanning.

**Binary size:** `fff-search` pulls LMDB (`heed`), `notify`, and `neo_frizbee`. `git2` was already a dep.

## Test plan

- [ ] `cargo check` passes (verified locally)
- [ ] `bun run typecheck` passes (verified locally)
- [ ] Open a folder → global search → query matches with expected ordering
- [ ] Open a file a few times, reopen global search → it ranks higher on next query
- [ ] Modify a tracked file → it gets boosted
- [ ] Close & reopen workspace → frecency persists across sessions
- [ ] Large repo (10k+ files) — initial scan does not block the UI