### PR TITLE
Add Windows winget install fallback

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -120,6 +120,50 @@ The release workflow automatically:
 - Creates GitHub release
 - Uploads installers and binaries
 
+### Windows Package Manager
+
+Athas can be submitted to Windows Package Manager through a PR to
+[`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs). The package ID should be
+confirmed by the repo owner before submission. `AthasDev.Athas` is a recommended starting point,
+but do not treat it as final until the winget PR is reviewed.
+
+Required manifest details:
+
+- `PackageIdentifier`: owner-approved package ID, for example `AthasDev.Athas`
+- `PackageVersion`: the release version without the leading `v`
+- `Publisher`: Athas
+- `PackageName`: Athas
+- `License`: AGPL-3.0
+- `ShortDescription`: A lightweight, cross-platform code editor built with Tauri
+- `InstallerType`: `nullsoft`
+- `InstallerUrl`: GitHub Release setup `.exe`
+- `InstallerSha256`: matching SHA256 from `SHA256SUMS.txt`
+- Installer entries for both `x64` and `arm64`
+
+Example values from `v0.5.1`:
+
+```yaml
+PackageIdentifier: AthasDev.Athas
+PackageVersion: 0.5.1
+PackageName: Athas
+Publisher: Athas
+License: AGPL-3.0
+ShortDescription: A lightweight, cross-platform code editor built with Tauri
+Installers:
+  - Architecture: x64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/athasdev/athas/releases/download/v0.5.1/Athas_0.5.1_x64-setup.exe
+    InstallerSha256: eb219d7802cf010a40de598a576c341c0746f8cc8f56226fe16d57e6873c6dc2
+  - Architecture: arm64
+    InstallerType: nullsoft
+    InstallerUrl: https://github.com/athasdev/athas/releases/download/v0.5.1/Athas_0.5.1_arm64-setup.exe
+    InstallerSha256: 0abd9d390c27a4adeaef22c6a73d28a91c9431d68adb13efb898f029c4a5da95
+```
+
+Refresh the version, installer URLs, and SHA256 values for the release being submitted. After the
+first package is accepted and the final package ID is known, release automation can be added with
+`wingetcreate update`.
+
 ### Versioning
 
 We use semantic versioning: `MAJOR.MINOR.PATCH`.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -21,6 +21,30 @@ Download the latest version from GitHub releases:
     4. Open Athas from Applications
   </Tab>
   <Tab value="Windows">
+    **Option 1: winget**
+
+    Athas is preparing for Windows Package Manager distribution. After the package is accepted in
+    `microsoft/winget-pkgs`, install it with the owner-approved package ID:
+
+    ```powershell
+    winget install --exact --id OWNER_APPROVED_PACKAGE_ID --source winget
+    ```
+
+    **Option 2: verified GitHub Releases installer**
+
+    If winget is unavailable or the package is not accepted yet, download and run the verified
+    installer helper:
+
+    ```powershell
+    curl.exe -L https://raw.githubusercontent.com/athasdev/athas/master/scripts/windows/install-athas.ps1 -o install-athas.ps1
+    powershell -ExecutionPolicy Bypass -File .\install-athas.ps1 -SkipWinget
+    ```
+
+    The helper detects `x64` or `arm64`, downloads the matching setup `.exe`, verifies it with
+    `SHA256SUMS.txt`, and runs the installer.
+
+    **Option 3: manual download**
+
     1. Download the installer from [releases](https://github.com/athasdev/athas/releases)
     2. Run the installer
     3. Follow the installation wizard

--- a/scripts/windows/install-athas.ps1
+++ b/scripts/windows/install-athas.ps1
@@ -1,0 +1,248 @@
+param(
+    [switch]$SkipWinget,
+    [switch]$Interactive,
+    [switch]$DryRun,
+    [ValidateSet("x64", "arm64")]
+    [string]$Architecture,
+    [string]$Version,
+    [string]$InstallDir,
+    [string]$PackageId = "AthasDev.Athas"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Repository = "athasdev/athas"
+$ReleaseBaseUrl = "https://github.com/$Repository/releases"
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "athas-installer"
+
+function Write-Status {
+    param([string]$Message)
+    Write-Host "[INFO] $Message" -ForegroundColor Blue
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "[SUCCESS] $Message" -ForegroundColor Green
+}
+
+function Write-WarningMessage {
+    param([string]$Message)
+    Write-Host "[WARNING] $Message" -ForegroundColor Yellow
+}
+
+function Write-Failure {
+    param([string]$Message)
+    Write-Host "[ERROR] $Message" -ForegroundColor Red
+}
+
+function Command-Exists {
+    param([string]$Command)
+    return $null -ne (Get-Command $Command -ErrorAction SilentlyContinue)
+}
+
+function Resolve-Architecture {
+    if ($Architecture) {
+        return $Architecture
+    }
+
+    $processorArchitecture = $env:PROCESSOR_ARCHITECTURE
+    $wow64Architecture = $env:PROCESSOR_ARCHITEW6432
+
+    if ($processorArchitecture -match "ARM64" -or $wow64Architecture -match "ARM64") {
+        return "arm64"
+    }
+
+    if ($processorArchitecture -match "AMD64" -or $processorArchitecture -match "x86") {
+        return "x64"
+    }
+
+    throw "Unsupported Windows architecture: $processorArchitecture"
+}
+
+function Get-LatestVersion {
+    if ($Version) {
+        return $Version.TrimStart("v")
+    }
+
+    $latestUrl = "https://api.github.com/repos/$Repository/releases/latest"
+    Write-Status "Resolving latest Athas release..."
+    $release = Invoke-RestMethod -Uri $latestUrl -Headers @{ "User-Agent" = "athas-installer" }
+    return ([string]$release.tag_name).TrimStart("v")
+}
+
+function Invoke-Download {
+    param(
+        [string]$Uri,
+        [string]$OutFile
+    )
+
+    if ($DryRun) {
+        Write-Status "Dry run: would download $Uri"
+        Write-Status "Dry run: target path $OutFile"
+        return
+    }
+
+    if (Command-Exists "curl.exe") {
+        & curl.exe --fail --location --show-error --output $OutFile $Uri
+        if ($LASTEXITCODE -ne 0) {
+            throw "curl.exe failed to download $Uri"
+        }
+        return
+    }
+
+    Invoke-WebRequest -Uri $Uri -OutFile $OutFile -Headers @{ "User-Agent" = "athas-installer" }
+}
+
+function Get-ExpectedHashFromLines {
+    param(
+        [string[]]$ChecksumLines,
+        [string]$FileName
+    )
+
+    $escapedFileName = [regex]::Escape($FileName)
+    $line = $ChecksumLines | Where-Object { $_ -match "^\s*([a-fA-F0-9]{64})\s+$escapedFileName\s*$" } | Select-Object -First 1
+    if (-not $line) {
+        throw "Could not find SHA256 checksum for $FileName"
+    }
+
+    return ([regex]::Match($line, "([a-fA-F0-9]{64})")).Groups[1].Value.ToLowerInvariant()
+}
+
+function Get-ExpectedHash {
+    param(
+        [string]$ChecksumsPath,
+        [string]$FileName
+    )
+
+    return Get-ExpectedHashFromLines -ChecksumLines (Get-Content $ChecksumsPath) -FileName $FileName
+}
+
+function Test-InstallerHash {
+    param(
+        [string]$InstallerPath,
+        [string]$ExpectedHash
+    )
+
+    $actualHash = (Get-FileHash -Path $InstallerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualHash -ne $ExpectedHash) {
+        throw "SHA256 mismatch for $InstallerPath. Expected $ExpectedHash, got $actualHash"
+    }
+
+    Write-Success "Verified installer SHA256: $actualHash"
+}
+
+function Install-WithWinget {
+    if ($SkipWinget) {
+        Write-Status "Skipping winget install."
+        return $false
+    }
+
+    if (-not (Command-Exists "winget")) {
+        Write-WarningMessage "winget is not available; falling back to GitHub Releases."
+        return $false
+    }
+
+    $wingetArgs = @(
+        "install",
+        "--exact",
+        "--id",
+        $PackageId,
+        "--source",
+        "winget",
+        "--accept-package-agreements",
+        "--accept-source-agreements"
+    )
+
+    if ($Interactive) {
+        $wingetArgs += "--interactive"
+    } else {
+        $wingetArgs += "--silent"
+    }
+
+    if ($InstallDir) {
+        $wingetArgs += @("--location", $InstallDir)
+    }
+
+    Write-Status "Trying winget package: $PackageId"
+    if ($DryRun) {
+        Write-Status "Dry run: winget $($wingetArgs -join ' ')"
+        return $false
+    }
+
+    & winget @wingetArgs
+    if ($LASTEXITCODE -eq 0) {
+        Write-Success "Athas installed with winget."
+        return $true
+    }
+
+    Write-WarningMessage "winget install failed with exit code $LASTEXITCODE; falling back to GitHub Releases."
+    return $false
+}
+
+function Install-FromGitHubRelease {
+    $resolvedArchitecture = Resolve-Architecture
+    $resolvedVersion = Get-LatestVersion
+    $tag = "v$resolvedVersion"
+    $installerName = "Athas_${resolvedVersion}_${resolvedArchitecture}-setup.exe"
+    $installerUrl = "$ReleaseBaseUrl/download/$tag/$installerName"
+    $checksumsUrl = "$ReleaseBaseUrl/download/$tag/SHA256SUMS.txt"
+    $downloadDir = Join-Path $TempRoot $tag
+    $installerPath = Join-Path $downloadDir $installerName
+    $checksumsPath = Join-Path $downloadDir "SHA256SUMS.txt"
+
+    Write-Status "Selected Windows $resolvedArchitecture installer for Athas $tag."
+    Write-Status "Installer: $installerUrl"
+    Write-Status "Checksums: $checksumsUrl"
+
+    if ($DryRun) {
+        $checksumText = Invoke-RestMethod -Uri $checksumsUrl -Headers @{ "User-Agent" = "athas-installer" }
+        $checksumLines = [string[]]($checksumText -split "`r?`n")
+        $expectedHash = Get-ExpectedHashFromLines -ChecksumLines $checksumLines -FileName $installerName
+        Write-Status "Dry run: expected SHA256 $expectedHash"
+        Write-Status "Dry run: skipping installer download, verification, and execution."
+        return
+    }
+
+    New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+    Invoke-Download -Uri $installerUrl -OutFile $installerPath
+    Invoke-Download -Uri $checksumsUrl -OutFile $checksumsPath
+
+    $expectedHash = Get-ExpectedHash -ChecksumsPath $checksumsPath -FileName $installerName
+    Test-InstallerHash -InstallerPath $installerPath -ExpectedHash $expectedHash
+
+    $installerArgs = @()
+    if (-not $Interactive) {
+        $installerArgs += "/S"
+    }
+    if ($InstallDir) {
+        $installerArgs += "/D=$InstallDir"
+    }
+
+    Write-Status "Starting Athas installer..."
+    $process = Start-Process -FilePath $installerPath -ArgumentList $installerArgs -Wait -PassThru
+    if ($process.ExitCode -ne 0) {
+        throw "Athas installer failed with exit code $($process.ExitCode)"
+    }
+
+    Write-Success "Athas installer completed."
+}
+
+function Main {
+    if ($env:OS -and $env:OS -ne "Windows_NT") {
+        throw "This installer is designed for Windows."
+    }
+
+    if (Install-WithWinget) {
+        return
+    }
+
+    Install-FromGitHubRelease
+}
+
+try {
+    Main
+} catch {
+    Write-Failure $_.Exception.Message
+    exit 1
+}


### PR DESCRIPTION
## Summary

- add a Windows installer helper that tries winget first, then falls back to verified GitHub Release downloads
- document Windows install options in order: future winget package, verified helper, manual release download
- add maintainer guidance for the first `microsoft/winget-pkgs` submission with x64 and arm64 example values from `v0.5.1`

## Details

The helper defaults to the proposed package ID `AthasDev.Athas`, but the docs keep the public install command as `OWNER_APPROVED_PACKAGE_ID` because the final winget identifier should be decided during maintainer review.

The fallback path detects `x64` or `arm64`, resolves the requested/latest release, downloads `SHA256SUMS.txt`, verifies the matching setup `.exe`, and runs the NSIS installer silently unless `-Interactive` is passed.

## Validation

- `bun typecheck`
- `bun check`
- `git diff --check`
- `bun typecheck && bun lint` via pre-push hook
- Windows PowerShell validation:
  - PowerShell parse check passed
  - `-DryRun -SkipWinget -Architecture x64` resolved `v0.5.1` and SHA256 `eb219d7802cf010a40de598a576c341c0746f8cc8f56226fe16d57e6873c6dc2`
  - `-DryRun -SkipWinget -Architecture arm64` resolved `v0.5.1` and SHA256 `0abd9d390c27a4adeaef22c6a73d28a91c9431d68adb13efb898f029c4a5da95`
