### PR TITLE
Fix Linux Wayland window resize

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:default",
     "core:window:allow-start-dragging",
+    "core:window:allow-start-resize-dragging",
     "core:window:allow-close",
     "core:window:allow-destroy",
     "core:window:allow-minimize",

--- a/src/features/window/components/window-resize-border.tsx
+++ b/src/features/window/components/window-resize-border.tsx
@@ -135,6 +135,10 @@ const handleResizePointerDown = (
   event: PointerEvent<HTMLDivElement>,
   direction: ResizeDirection,
 ) => {
+  if (IS_LINUX) {
+    return;
+  }
+
   if (!event.isPrimary || !prepareResizeEvent(event)) {
     return;
   }
@@ -143,6 +147,18 @@ const handleResizePointerDown = (
 };
 
 const handleResizeMouseDown = (event: MouseEvent<HTMLDivElement>, direction: ResizeDirection) => {
+  if (IS_LINUX) {
+    // WebKitGTK on Linux/Wayland can alternate between firing and skipping
+    // pointerdown for compositor-driven window resize gestures, but mousedown
+    // remains reliable.
+    if (!prepareResizeEvent(event)) {
+      return;
+    }
+
+    void handleResizeStart(direction);
+    return;
+  }
+
   if (typeof window !== "undefined" && "PointerEvent" in window) {
     return;
   }


### PR DESCRIPTION
- Fix alternating Linux/Wayland resize gestures by using `mousedown` for resize handles by @bet4it
- Add the missing `start_resize_dragging` window capability by @bet4it