### PR TITLE
Polish explorer folder open, close, and collapse behavior

### DIFF
--- a/src/features/file-explorer/components/file-explorer-tree-item.tsx
+++ b/src/features/file-explorer/components/file-explorer-tree-item.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { memo } from "react";
+import { CaretDoubleUp, FolderOpen, Minus } from "@phosphor-icons/react";
 import {
   FILE_TREE_DENSITY_CONFIG,
   type FileTreeDensity,
@@ -19,6 +20,12 @@ export interface FileTreeGuideTarget {
   name: string;
   isDir: boolean;
   isActive: boolean;
+}
+
+export interface FileTreeRowAnimation {
+  delay: number;
+  duration: number;
+  phase: "opening-block" | "closing-block" | "closing";
 }
 
 function areGuideTargetsEqual(
@@ -52,12 +59,15 @@ interface FileExplorerTreeItemProps {
   density: FileTreeDensity;
   isExpanded: boolean;
   isActive: boolean;
+  isWorkspaceRoot: boolean;
+  rowAnimation?: FileTreeRowAnimation | null;
   dragOverPath: string | null;
   isDragging: boolean;
   editingValue: string;
   onEditingValueChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent, file: FileEntry) => void;
   onBlur: (file: FileEntry) => void;
+  onCollapseDirectory: (path: string, isWorkspaceRoot: boolean) => void;
   getGitStatusDecoration: (file: FileEntry) => FileTreeGitStatusDecoration | null;
   searchQuery?: string;
   isSearchMatch?: boolean;
@@ -96,12 +106,15 @@ function FileExplorerTreeItemComponent({
   density,
   isExpanded,
   isActive,
+  isWorkspaceRoot,
+  rowAnimation,
   dragOverPath,
   isDragging,
   editingValue,
   onEditingValueChange,
   onKeyDown,
   onBlur,
+  onCollapseDirectory,
   getGitStatusDecoration,
   searchQuery,
   isSearchMatch = false,
@@ -145,7 +158,15 @@ function FileExplorerTreeItemComponent({
 
   if (file.isEditing || file.isRenaming) {
     return (
-      <div className="file-tree-item w-full" data-depth={depth}>
+      <div
+        className="file-tree-item w-full"
+        data-depth={depth}
+        style={
+          {
+            "--file-tree-row-height": `${densityConfig.rowHeight}px`,
+          } as React.CSSProperties
+        }
+      >
         {renderTreeGuides()}
         <div
           className={cn(
@@ -201,6 +222,20 @@ function FileExplorerTreeItemComponent({
       className="file-tree-item w-full"
       data-active={isActive ? "true" : undefined}
       data-depth={depth}
+      data-row-animation={rowAnimation?.phase}
+      data-expanded={isExpanded ? "true" : undefined}
+      data-is-dir={file.isDir ? "true" : undefined}
+      style={
+        {
+          "--file-tree-row-height": `${densityConfig.rowHeight}px`,
+          ...(rowAnimation
+            ? {
+                "--file-tree-row-animation-delay": `${rowAnimation.delay}ms`,
+                "--file-tree-row-animation-duration": `${rowAnimation.duration}ms`,
+              }
+            : {}),
+        } as React.CSSProperties
+      }
     >
       {renderTreeGuides()}
       <TreeRow
@@ -218,6 +253,7 @@ function FileExplorerTreeItemComponent({
         }
         className={cn(
           densityConfig.rowClassName,
+          file.isDir && isExpanded && "pr-7",
           dragOverPath === file.path &&
             "!border-2 !border-dashed !border-accent !bg-accent !bg-opacity-20",
           isDragging && "cursor-move",
@@ -230,13 +266,21 @@ function FileExplorerTreeItemComponent({
         depth={depth}
         indentSize={indentSize}
       >
-        <FileExplorerIcon
-          fileName={file.name}
-          isDir={file.isDir}
-          isExpanded={isExpanded}
-          isSymlink={file.isSymlink}
-          className="relative z-1 shrink-0 text-text-lighter"
-        />
+        {isWorkspaceRoot ? (
+          <FolderOpen
+            size={14}
+            weight="duotone"
+            className="relative z-1 shrink-0 text-text-lighter"
+          />
+        ) : (
+          <FileExplorerIcon
+            fileName={file.name}
+            isDir={file.isDir}
+            isExpanded={isExpanded}
+            isSymlink={file.isSymlink}
+            className="relative z-1 shrink-0 text-text-lighter"
+          />
+        )}
         <span
           className={cn(
             "relative z-1 select-none whitespace-nowrap",
@@ -246,6 +290,30 @@ function FileExplorerTreeItemComponent({
           {renderHighlightedLabel(displayName ?? file.name, searchQuery)}
         </span>
       </TreeRow>
+      {file.isDir && isExpanded ? (
+        <button
+          type="button"
+          className="file-tree-row-action"
+          aria-label={
+            isWorkspaceRoot
+              ? `Collapse everything under ${displayName ?? file.name}`
+              : `Collapse ${displayName ?? file.name}`
+          }
+          title={isWorkspaceRoot ? "Collapse descendants" : "Collapse folder"}
+          tabIndex={-1}
+          onMouseDown={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onCollapseDirectory(file.path, isWorkspaceRoot);
+          }}
+        >
+          {isWorkspaceRoot ? <Minus weight="bold" /> : <CaretDoubleUp weight="bold" />}
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -263,12 +331,17 @@ export const FileExplorerTreeItem = memo(
     prev.density === next.density &&
     prev.isExpanded === next.isExpanded &&
     prev.isActive === next.isActive &&
+    prev.isWorkspaceRoot === next.isWorkspaceRoot &&
+    prev.rowAnimation?.delay === next.rowAnimation?.delay &&
+    prev.rowAnimation?.duration === next.rowAnimation?.duration &&
+    prev.rowAnimation?.phase === next.rowAnimation?.phase &&
     prev.dragOverPath === next.dragOverPath &&
     prev.isDragging === next.isDragging &&
     prev.editingValue === next.editingValue &&
     prev.onEditingValueChange === next.onEditingValueChange &&
     prev.onKeyDown === next.onKeyDown &&
     prev.onBlur === next.onBlur &&
+    prev.onCollapseDirectory === next.onCollapseDirectory &&
     prev.getGitStatusDecoration === next.getGitStatusDecoration &&
     prev.searchQuery === next.searchQuery &&
     prev.isSearchMatch === next.isSearchMatch &&

--- a/src/features/file-explorer/components/file-explorer-tree.tsx
+++ b/src/features/file-explorer/components/file-explorer-tree.tsx
@@ -954,7 +954,9 @@ function FileExplorerTreeComponent({
     if (!openingPath) return;
 
     const descendantVisiblePaths = visibleRows
-      .filter((row) => row.file.path !== openingPath && pathStartsWithRoot(row.file.path, openingPath))
+      .filter(
+        (row) => row.file.path !== openingPath && pathStartsWithRoot(row.file.path, openingPath),
+      )
       .map((row) => row.file.path);
 
     pendingOpenAnimationPathRef.current = null;

--- a/src/features/file-explorer/components/file-explorer-tree.tsx
+++ b/src/features/file-explorer/components/file-explorer-tree.tsx
@@ -1,9 +1,12 @@
 import ignore from "ignore";
 import {
+  CaretDoubleUp,
   Check,
   Eye,
   Funnel,
+  FolderOpen,
   GitBranch,
+  Minus,
   MagnifyingGlass as Search,
   Warning as AlertTriangle,
 } from "@phosphor-icons/react";
@@ -61,7 +64,7 @@ import { useFileExplorerDragDrop } from "../hooks/use-file-explorer-drag-drop";
 import { useFileExplorerSync } from "../hooks/use-file-explorer-sync";
 import { useFileExplorerVisibleRows } from "../hooks/use-file-explorer-visible-rows";
 import { FILE_TREE_BASE_INDENT, FileExplorerTreeItem } from "./file-explorer-tree-item";
-import type { FileTreeGuideTarget } from "./file-explorer-tree-item";
+import type { FileTreeGuideTarget, FileTreeRowAnimation } from "./file-explorer-tree-item";
 import { FileExplorerIcon } from "./file-explorer-icon";
 import "../styles/file-explorer-tree.css";
 
@@ -113,7 +116,25 @@ interface OpenAllFilesDialogState {
 
 const FILE_TREE_CONTAINER_INSET = 4;
 const FILE_TREE_HEADER_HEIGHT = 32;
+const FOLDER_COLLAPSE_TOTAL_DURATION_MS = 500;
+const FOLDER_ROW_ANIMATION_DURATION_MS = 240;
 const getFileTreeRowId = (path: string) => `file-tree-row-${path.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+
+function getPathDepth(path: string): number {
+  return stripTrailingPathSeparators(path).split(/[/\\]/).filter(Boolean).length;
+}
+
+function getCollapseStackDelay(index: number, total: number): number {
+  if (total <= 1) return 0;
+
+  const progress = index / (total - 1);
+  const maxDelay = Math.max(
+    0,
+    FOLDER_COLLAPSE_TOTAL_DURATION_MS - FOLDER_ROW_ANIMATION_DURATION_MS,
+  );
+
+  return Math.round(progress ** 3 * maxDelay);
+}
 
 function FileExplorerTreeComponent({
   files,
@@ -142,6 +163,7 @@ function FileExplorerTreeComponent({
   const [openAllFilesDialog, setOpenAllFilesDialog] = useState<OpenAllFilesDialogState | null>(
     null,
   );
+  const [rowAnimations, setRowAnimations] = useState<Record<string, FileTreeRowAnimation>>({});
   const [isDeletingPath, setIsDeletingPath] = useState(false);
   const [isOpeningAllFiles, setIsOpeningAllFiles] = useState(false);
   const [editingValue, setEditingValue] = useState("");
@@ -154,6 +176,8 @@ function FileExplorerTreeComponent({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const filterButtonRef = useRef<HTMLButtonElement>(null);
   const documentRef = useRef<Document>(document);
+  const collapseAnimationTimeoutsRef = useRef<number[]>([]);
+  const pendingOpenAnimationPathRef = useRef<string | null>(null);
 
   const [gitIgnoreRules, setGitIgnoreRules] = useState<FileTreeGitIgnoreRules | null>(null);
   const workspaceGitStatus = useGitStore((state) => state.workspaceGitStatus);
@@ -429,6 +453,10 @@ function FileExplorerTreeComponent({
     containerRef,
     expandedPathsOverride: displayedExpandedPaths,
   });
+  const rootRowPaths = useMemo(
+    () => new Set(visibleRows.filter((row) => row.depth === 0).map((row) => row.file.path)),
+    [visibleRows],
+  );
   const keyboardPath = focusedPath || activePath;
   const highlightedPath = hasTreeFocus ? keyboardPath : activePath;
 
@@ -763,41 +791,6 @@ function FileExplorerTreeComponent({
     }
   }, [openAllFilesDialog, openFilePathsInTabs]);
 
-  const { setContextMenu, handleContextMenu, contextMenuElement } = useFileExplorerContextMenu({
-    rootFolderPath,
-    onFileSelect,
-    onCreateNewFileInDirectory,
-    onCreateNewFolderInDirectory,
-    onGenerateImage,
-    onRefreshDirectory,
-    onRenamePath,
-    onRevealInFinder,
-    onUploadFile,
-    onDuplicatePath,
-    onAddFolderToWorkspace: () => {
-      void addFolderToWorkspace();
-    },
-    onRemoveFolderFromWorkspace: (path) => {
-      void removeFolderFromWorkspace(path);
-    },
-    isWorkspaceRootPath: (path) => workspaceRootPaths.includes(path),
-    canRemoveWorkspaceRootPath: (path) =>
-      path !== rootFolderPath && workspaceRootPaths.includes(path),
-    onDeleteRequested: setDeleteCandidate,
-    onStartInlineEditing: startInlineEditing,
-    onOpenAllFilesInDirectory: handleOpenAllFilesInDirectory,
-  });
-
-  useEventListener(
-    "keydown",
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") setContextMenu(null);
-    },
-    documentRef,
-  );
-
-  useEventListener("dragover", (e: DragEvent) => e.preventDefault(), documentRef);
-
   // Fast path->file lookup for delegation
   const pathToFile = useMemo(() => {
     const m = new Map<string, FileEntry>();
@@ -819,10 +812,213 @@ function FileExplorerTreeComponent({
 
   const toggleDirectory = useCallback(
     async (path: string) => {
+      if (!useFileTreeStore.getState().isExpanded(path)) {
+        pendingOpenAnimationPathRef.current = path;
+      }
+
       await Promise.resolve(onFileSelect(path, true));
     },
     [onFileSelect],
   );
+
+  const clearCollapseAnimation = useCallback(() => {
+    collapseAnimationTimeoutsRef.current.forEach((timeoutId) => window.clearTimeout(timeoutId));
+    collapseAnimationTimeoutsRef.current = [];
+    pendingOpenAnimationPathRef.current = null;
+    setRowAnimations({});
+  }, []);
+
+  const closeDirectory = useCallback(
+    (path: string) => {
+      const descendantVisiblePaths = visibleRows
+        .filter((row) => row.file.path !== path && pathStartsWithRoot(row.file.path, path))
+        .map((row) => row.file.path);
+
+      if (descendantVisiblePaths.length === 0) {
+        useFileTreeStore.getState().toggleFolder(path);
+        return;
+      }
+
+      clearCollapseAnimation();
+
+      setRowAnimations(
+        Object.fromEntries(
+          descendantVisiblePaths.map((targetPath) => [
+            targetPath,
+            {
+              delay: 0,
+              duration: FOLDER_ROW_ANIMATION_DURATION_MS,
+              phase: "closing-block" as const,
+            },
+          ]),
+        ),
+      );
+
+      const timeoutId = window.setTimeout(() => {
+        useFileTreeStore.getState().toggleFolder(path);
+        setRowAnimations({});
+        collapseAnimationTimeoutsRef.current = collapseAnimationTimeoutsRef.current.filter(
+          (currentTimeoutId) => currentTimeoutId !== timeoutId,
+        );
+      }, FOLDER_ROW_ANIMATION_DURATION_MS);
+
+      collapseAnimationTimeoutsRef.current.push(timeoutId);
+    },
+    [clearCollapseAnimation, visibleRows],
+  );
+
+  const collapseDirectory = useCallback(
+    (path: string, isWorkspaceRoot: boolean) => {
+      const treeState = useFileTreeStore.getState();
+      const expandedPaths = Array.from(treeState.getExpandedPaths()).filter(
+        (expandedPath) =>
+          pathStartsWithRoot(expandedPath, path) && (!isWorkspaceRoot || expandedPath !== path),
+      );
+      const descendantVisibleRows = visibleRows.filter(
+        (row) => row.file.path !== path && pathStartsWithRoot(row.file.path, path),
+      );
+      const descendantVisiblePaths = descendantVisibleRows.map((row) => row.file.path);
+
+      if (expandedPaths.length === 0 && descendantVisiblePaths.length === 0) return;
+
+      clearCollapseAnimation();
+
+      const folderCollapseOrder = descendantVisibleRows
+        .filter((row) => row.file.isDir)
+        .map((row) => row.file.path)
+        .sort((left, right) => {
+          const depthDifference = getPathDepth(right) - getPathDepth(left);
+          if (depthDifference !== 0) return depthDifference;
+          return right.length - left.length;
+        });
+
+      const closeAnimationByPath = Object.fromEntries(
+        descendantVisiblePaths.map((targetPath) => [
+          targetPath,
+          {
+            delay: 0,
+            duration: FOLDER_ROW_ANIMATION_DURATION_MS,
+            phase: "closing" as const,
+          },
+        ]),
+      );
+
+      folderCollapseOrder.forEach((targetPath, index) => {
+        closeAnimationByPath[targetPath] = {
+          delay: getCollapseStackDelay(index, folderCollapseOrder.length),
+          duration: FOLDER_ROW_ANIMATION_DURATION_MS,
+          phase: "closing",
+        };
+      });
+
+      const totalCloseDuration =
+        folderCollapseOrder.length > 0
+          ? getCollapseStackDelay(folderCollapseOrder.length - 1, folderCollapseOrder.length) +
+            FOLDER_ROW_ANIMATION_DURATION_MS
+          : descendantVisiblePaths.length > 0
+            ? FOLDER_ROW_ANIMATION_DURATION_MS
+            : 0;
+
+      if (descendantVisiblePaths.length > 0) {
+        setRowAnimations(closeAnimationByPath);
+      }
+
+      const timeoutId = window.setTimeout(() => {
+        if (isWorkspaceRoot) {
+          const nextExpandedPaths = new Set(
+            Array.from(useFileTreeStore.getState().getExpandedPaths()).filter(
+              (expandedPath) => !pathStartsWithRoot(expandedPath, path) || expandedPath === path,
+            ),
+          );
+          nextExpandedPaths.add(path);
+          useFileTreeStore.getState().setExpandedPaths(nextExpandedPaths);
+        } else {
+          useFileTreeStore.getState().collapsePath(path);
+        }
+
+        setRowAnimations({});
+        collapseAnimationTimeoutsRef.current = collapseAnimationTimeoutsRef.current.filter(
+          (currentTimeoutId) => currentTimeoutId !== timeoutId,
+        );
+      }, totalCloseDuration);
+
+      collapseAnimationTimeoutsRef.current.push(timeoutId);
+    },
+    [clearCollapseAnimation, visibleRows],
+  );
+
+  useEffect(() => () => clearCollapseAnimation(), [clearCollapseAnimation]);
+
+  useEffect(() => {
+    const openingPath = pendingOpenAnimationPathRef.current;
+    if (!openingPath) return;
+
+    const descendantVisiblePaths = visibleRows
+      .filter((row) => row.file.path !== openingPath && pathStartsWithRoot(row.file.path, openingPath))
+      .map((row) => row.file.path);
+
+    pendingOpenAnimationPathRef.current = null;
+
+    if (descendantVisiblePaths.length === 0) return;
+
+    setRowAnimations(
+      Object.fromEntries(
+        descendantVisiblePaths.map((targetPath) => [
+          targetPath,
+          {
+            delay: 0,
+            duration: FOLDER_ROW_ANIMATION_DURATION_MS,
+            phase: "opening-block" as const,
+          },
+        ]),
+      ),
+    );
+
+    const timeoutId = window.setTimeout(() => {
+      setRowAnimations({});
+      collapseAnimationTimeoutsRef.current = collapseAnimationTimeoutsRef.current.filter(
+        (currentTimeoutId) => currentTimeoutId !== timeoutId,
+      );
+    }, FOLDER_ROW_ANIMATION_DURATION_MS);
+
+    collapseAnimationTimeoutsRef.current.push(timeoutId);
+  }, [visibleRows]);
+
+  const { setContextMenu, handleContextMenu, contextMenuElement } = useFileExplorerContextMenu({
+    rootFolderPath,
+    onFileSelect,
+    onCreateNewFileInDirectory,
+    onCreateNewFolderInDirectory,
+    onGenerateImage,
+    onRefreshDirectory,
+    onRenamePath,
+    onRevealInFinder,
+    onUploadFile,
+    onDuplicatePath,
+    onAddFolderToWorkspace: () => {
+      void addFolderToWorkspace();
+    },
+    onRemoveFolderFromWorkspace: (path) => {
+      void removeFolderFromWorkspace(path);
+    },
+    isWorkspaceRootPath: (path) => workspaceRootPaths.includes(path),
+    canRemoveWorkspaceRootPath: (path) =>
+      path !== rootFolderPath && workspaceRootPaths.includes(path),
+    onCollapseDirectory: collapseDirectory,
+    onDeleteRequested: setDeleteCandidate,
+    onStartInlineEditing: startInlineEditing,
+    onOpenAllFilesInDirectory: handleOpenAllFilesInDirectory,
+  });
+
+  useEventListener(
+    "keydown",
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") setContextMenu(null);
+    },
+    documentRef,
+  );
+
+  useEventListener("dragover", (e: DragEvent) => e.preventDefault(), documentRef);
 
   const handleContainerClick = useCallback(
     (e: React.MouseEvent) => {
@@ -841,7 +1037,14 @@ function FileExplorerTreeComponent({
         fileOpenBenchmark.mark(t.path, "explorer-click");
       }
       if (t.isDir) {
-        void toggleDirectory(t.path);
+        const isWorkspaceRoot = rootRowPaths.has(t.path);
+        const isExpanded = useFileTreeStore.getState().isExpanded(t.path);
+
+        if (isExpanded && !isWorkspaceRoot) {
+          closeDirectory(t.path);
+        } else if (!isExpanded || !isWorkspaceRoot) {
+          void toggleDirectory(t.path);
+        }
         setFocusedPath(t.path);
         updateActivePath?.(t.path);
       } else {
@@ -849,7 +1052,7 @@ function FileExplorerTreeComponent({
         void Promise.resolve(onFileSelect(t.path, false));
       }
     },
-    [onFileSelect, toggleDirectory, updateActivePath, pathToFile],
+    [closeDirectory, onFileSelect, rootRowPaths, toggleDirectory, updateActivePath],
   );
 
   const handleContainerDoubleClick = useCallback(
@@ -1105,8 +1308,12 @@ function FileExplorerTreeComponent({
           case "ArrowLeft": {
             if (!current) break;
             e.preventDefault();
-            if (isDir && useFileTreeStore.getState().isExpanded(current.path)) {
-              void toggleDirectory(current.path);
+            if (
+              isDir &&
+              useFileTreeStore.getState().isExpanded(current.path) &&
+              !rootRowPaths.has(current.path)
+            ) {
+              closeDirectory(current.path);
             } else {
               const sep = current.path.includes("\\") ? "\\" : "/";
               const parentPath = current.path.split(sep).slice(0, -1).join(sep);
@@ -1122,7 +1329,14 @@ function FileExplorerTreeComponent({
             if (!current) break;
             e.preventDefault();
             if (isDir) {
-              void toggleDirectory(current.path);
+              const isWorkspaceRoot = rootRowPaths.has(current.path);
+              const isExpanded = useFileTreeStore.getState().isExpanded(current.path);
+
+              if (isExpanded && !isWorkspaceRoot) {
+                closeDirectory(current.path);
+              } else if (!isWorkspaceRoot || !isExpanded) {
+                void toggleDirectory(current.path);
+              }
             } else {
               void Promise.resolve(onFileOpen?.(current.path, false));
             }
@@ -1240,42 +1454,106 @@ function FileExplorerTreeComponent({
                         const stickyAncestorLabel =
                           stickyAncestor.displayName ?? stickyAncestor.file.name;
                         const stickyAncestorGitStatus = getGitStatusDecoration(stickyAncestor.file);
+                        const isStickyWorkspaceRoot = stickyAncestor.depth === 0;
                         const stickyAncestorPaddingLeft =
                           FILE_TREE_BASE_INDENT +
                           FILE_TREE_CONTAINER_INSET +
                           stickyAncestor.depth * settings.fileTreeIndentSize;
 
                         return (
-                          <button
+                          <div
                             key={stickyAncestor.file.path}
-                            type="button"
-                            data-file-path={stickyAncestor.file.path}
-                            data-is-dir={stickyAncestor.file.isDir}
-                            data-path={stickyAncestor.file.path}
-                            data-depth={stickyAncestor.depth}
-                            title={stickyAncestor.file.path}
-                            className={cn(
-                              "file-tree-row ui-font ui-text-xs flex w-full min-w-max cursor-pointer select-none items-center whitespace-nowrap rounded-none border-none bg-transparent text-left text-text outline-none transition-colors duration-150 hover:bg-hover focus:outline-none",
-                              densityConfig.rowClassName,
-                            )}
-                            style={{ paddingLeft: `${stickyAncestorPaddingLeft}px` }}
+                            className="file-tree-item w-full"
+                            data-active={
+                              highlightedPath === stickyAncestor.file.path ? "true" : undefined
+                            }
+                            data-expanded={stickyAncestor.isExpanded ? "true" : undefined}
+                            data-is-dir={stickyAncestor.file.isDir ? "true" : undefined}
+                            style={
+                              {
+                                "--file-tree-row-height": `${densityConfig.rowHeight}px`,
+                              } as React.CSSProperties
+                            }
                           >
-                            <FileExplorerIcon
-                              fileName={stickyAncestor.file.name}
-                              isDir={stickyAncestor.file.isDir}
-                              isExpanded={stickyAncestor.isExpanded}
-                              isSymlink={stickyAncestor.file.isSymlink}
-                              className="relative z-1 shrink-0 text-text-lighter"
-                            />
-                            <span
+                            <button
+                              type="button"
+                              id={getFileTreeRowId(stickyAncestor.file.path)}
+                              role="treeitem"
+                              aria-level={stickyAncestor.depth + 1}
+                              aria-selected={highlightedPath === stickyAncestor.file.path}
+                              aria-expanded={
+                                stickyAncestor.file.isDir ? stickyAncestor.isExpanded : undefined
+                              }
+                              data-file-path={stickyAncestor.file.path}
+                              data-is-dir={stickyAncestor.file.isDir}
+                              data-path={stickyAncestor.file.path}
+                              data-depth={stickyAncestor.depth}
+                              title={stickyAncestor.file.path}
                               className={cn(
-                                "relative z-1 select-none whitespace-nowrap",
-                                stickyAncestorGitStatus?.colorClassName,
+                                "file-tree-row ui-font ui-text-xs flex w-full min-w-max cursor-pointer select-none items-center whitespace-nowrap rounded-none border-none bg-transparent text-left text-text outline-none focus:outline-none",
+                                stickyAncestor.file.isDir && stickyAncestor.isExpanded && "pr-7",
+                                densityConfig.rowClassName,
                               )}
+                              style={{ paddingLeft: `${stickyAncestorPaddingLeft}px` }}
                             >
-                              {stickyAncestorLabel}
-                            </span>
-                          </button>
+                              {isStickyWorkspaceRoot ? (
+                                <FolderOpen
+                                  size={14}
+                                  weight="duotone"
+                                  className="relative z-1 shrink-0 text-text-lighter"
+                                />
+                              ) : (
+                                <FileExplorerIcon
+                                  fileName={stickyAncestor.file.name}
+                                  isDir={stickyAncestor.file.isDir}
+                                  isExpanded={stickyAncestor.isExpanded}
+                                  isSymlink={stickyAncestor.file.isSymlink}
+                                  className="relative z-1 shrink-0 text-text-lighter"
+                                />
+                              )}
+                              <span
+                                className={cn(
+                                  "relative z-1 select-none whitespace-nowrap",
+                                  stickyAncestorGitStatus?.colorClassName,
+                                )}
+                              >
+                                {stickyAncestorLabel}
+                              </span>
+                            </button>
+                            {stickyAncestor.file.isDir && stickyAncestor.isExpanded ? (
+                              <button
+                                type="button"
+                                className="file-tree-row-action"
+                                aria-label={
+                                  isStickyWorkspaceRoot
+                                    ? `Collapse everything under ${stickyAncestorLabel}`
+                                    : `Collapse ${stickyAncestorLabel}`
+                                }
+                                title={
+                                  isStickyWorkspaceRoot ? "Collapse descendants" : "Collapse folder"
+                                }
+                                tabIndex={-1}
+                                onMouseDown={(event) => {
+                                  event.preventDefault();
+                                  event.stopPropagation();
+                                }}
+                                onClick={(event) => {
+                                  event.preventDefault();
+                                  event.stopPropagation();
+                                  collapseDirectory(
+                                    stickyAncestor.file.path,
+                                    isStickyWorkspaceRoot,
+                                  );
+                                }}
+                              >
+                                {isStickyWorkspaceRoot ? (
+                                  <Minus weight="bold" />
+                                ) : (
+                                  <CaretDoubleUp weight="bold" />
+                                )}
+                              </button>
+                            ) : null}
+                          </div>
                         );
                       })}
                     </div>
@@ -1316,12 +1594,15 @@ function FileExplorerTreeComponent({
                       density={fileTreeDensity}
                       isExpanded={row.isExpanded}
                       isActive={highlightedPath === row.file.path}
+                      isWorkspaceRoot={rootRowPaths.has(row.file.path)}
+                      rowAnimation={rowAnimations[row.file.path]}
                       dragOverPath={dragState.dragOverPath}
                       isDragging={dragState.isDragging}
                       editingValue={editingValue}
                       onEditingValueChange={setEditingValue}
                       onKeyDown={handleKeyDown}
                       onBlur={handleBlur}
+                      onCollapseDirectory={collapseDirectory}
                       getGitStatusDecoration={getGitStatusDecoration}
                       rowId={getFileTreeRowId(row.file.path)}
                       searchQuery={isTreeSearchActive ? treeSearchQuery : undefined}

--- a/src/features/file-explorer/hooks/use-file-explorer-context-menu.tsx
+++ b/src/features/file-explorer/hooks/use-file-explorer-context-menu.tsx
@@ -251,7 +251,9 @@ export function useFileExplorerContextMenu({
         },
         {
           id: "collapse-all",
-          label: isWorkspaceRootPath?.(contextMenu.path) ? "Collapse Descendants" : "Collapse Folder",
+          label: isWorkspaceRootPath?.(contextMenu.path)
+            ? "Collapse Descendants"
+            : "Collapse Folder",
           icon: <CaretDoubleUp />,
           onClick: () => {
             if (onCollapseDirectory) {

--- a/src/features/file-explorer/hooks/use-file-explorer-context-menu.tsx
+++ b/src/features/file-explorer/hooks/use-file-explorer-context-menu.tsx
@@ -57,6 +57,7 @@ interface UseFileExplorerContextMenuOptions {
   onRemoveFolderFromWorkspace?: (path: string) => void;
   isWorkspaceRootPath?: (path: string) => boolean;
   canRemoveWorkspaceRootPath?: (path: string) => boolean;
+  onCollapseDirectory?: (path: string, isWorkspaceRoot: boolean) => void;
   onDeleteRequested: (candidate: { path: string; isDir: boolean }) => void;
   onStartInlineEditing: (path: string, isFolder: boolean) => void;
   onOpenAllFilesInDirectory: (directoryPath: string) => Promise<void>;
@@ -107,6 +108,7 @@ export function useFileExplorerContextMenu({
   onRemoveFolderFromWorkspace,
   isWorkspaceRootPath,
   canRemoveWorkspaceRootPath,
+  onCollapseDirectory,
   onDeleteRequested,
   onStartInlineEditing,
   onOpenAllFilesInDirectory,
@@ -249,9 +251,18 @@ export function useFileExplorerContextMenu({
         },
         {
           id: "collapse-all",
-          label: "Collapse All",
+          label: isWorkspaceRootPath?.(contextMenu.path) ? "Collapse Descendants" : "Collapse Folder",
           icon: <CaretDoubleUp />,
-          onClick: () => useFileTreeStore.getState().collapsePath(contextMenu.path),
+          onClick: () => {
+            if (onCollapseDirectory) {
+              onCollapseDirectory(
+                contextMenu.path,
+                Boolean(isWorkspaceRootPath?.(contextMenu.path)),
+              );
+              return;
+            }
+            useFileTreeStore.getState().collapsePath(contextMenu.path);
+          },
         },
         {
           id: "open-terminal",

--- a/src/features/file-explorer/styles/file-explorer-tree.css
+++ b/src/features/file-explorer/styles/file-explorer-tree.css
@@ -28,10 +28,17 @@
 .file-tree-item {
   width: 100% !important;
   min-width: 100% !important;
+  position: relative;
+  overflow: hidden;
+  max-height: var(--file-tree-row-height);
+  transform-origin: top;
+  --file-tree-hover-bg: color-mix(in srgb, var(--color-hover) 68%, transparent);
+  --file-tree-guide-icon-offset: 7px;
+  --tree-guide-color: color-mix(in srgb, var(--color-text-lighter) 18%, transparent);
 }
 
-/* All file tree items have same background behavior - ensure full width coverage */
-.file-tree-container .file-tree-item button {
+/* All file tree rows have same background behavior - ensure full width coverage */
+.file-tree-container .file-tree-item .file-tree-row {
   box-sizing: border-box !important;
   border: 1px solid transparent !important;
   border-radius: 2px !important;
@@ -42,25 +49,18 @@
   justify-content: flex-start !important;
 }
 
-.file-tree-container .file-tree-item button:hover {
+.file-tree-container .file-tree-item .file-tree-row:hover {
   background-color: transparent !important;
 }
 
-.file-tree-container .file-tree-item button.bg-selected,
-.file-tree-container .file-tree-item button.bg-selected:hover {
+.file-tree-container .file-tree-item .file-tree-row.bg-selected,
+.file-tree-container .file-tree-item .file-tree-row.bg-selected:hover {
   border-color: color-mix(in srgb, var(--color-border) 78%, transparent) !important;
   background-color: transparent !important;
 }
 
-.file-tree-container .file-tree-item button:focus-visible {
+.file-tree-container .file-tree-item .file-tree-row:focus-visible {
   border-color: color-mix(in srgb, var(--color-accent) 42%, var(--color-border)) !important;
-}
-
-.file-tree-item {
-  position: relative;
-  --file-tree-hover-bg: color-mix(in srgb, var(--color-hover) 68%, transparent);
-  --file-tree-guide-icon-offset: 7px;
-  --tree-guide-color: color-mix(in srgb, var(--color-text-lighter) 18%, transparent);
 }
 
 .file-tree-item::before {
@@ -84,6 +84,113 @@
 .file-tree-row {
   position: relative;
   z-index: 2;
+  isolation: isolate;
+}
+
+.file-tree-item[data-row-animation="opening-block"] {
+  animation: file-tree-row-open-block var(--file-tree-row-animation-duration, 240ms)
+    cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--file-tree-row-animation-delay, 0ms);
+  pointer-events: none;
+}
+
+.file-tree-item[data-row-animation="closing-block"] {
+  animation: file-tree-row-close-block var(--file-tree-row-animation-duration, 240ms)
+    cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--file-tree-row-animation-delay, 0ms);
+  pointer-events: none;
+}
+
+.file-tree-item[data-row-animation="closing"] {
+  animation: file-tree-row-close var(--file-tree-row-animation-duration, 240ms)
+    cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: var(--file-tree-row-animation-delay, 0ms);
+  pointer-events: none;
+}
+
+@keyframes file-tree-row-open-block {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes file-tree-row-close-block {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
+@keyframes file-tree-row-close {
+  from {
+    max-height: var(--file-tree-row-height);
+    opacity: 1;
+  }
+
+  to {
+    max-height: 0;
+    opacity: 0;
+  }
+}
+
+.file-tree-row-action {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  z-index: 2;
+  display: inline-flex;
+  height: 16px;
+  width: 16px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: color-mix(in srgb, var(--color-text-lighter) 70%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%) translateX(2px);
+  transition:
+    opacity 400ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 400ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 400ms cubic-bezier(0.22, 1, 0.36, 1),
+    color 400ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.file-tree-row-action svg {
+  height: 10px;
+  width: 10px;
+}
+
+.file-tree-row-action:hover {
+  background-color: color-mix(in srgb, var(--color-hover) 62%, transparent);
+  color: color-mix(in srgb, var(--color-text) 88%, var(--color-text-lighter));
+}
+
+.file-tree-item[data-is-dir="true"][data-expanded="true"][data-active="true"] .file-tree-row-action,
+.file-tree-item:focus-within .file-tree-row-action {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-50%) translateX(0);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .file-tree-item:hover .file-tree-row-action {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(-50%) translateX(0);
+  }
 }
 
 .file-tree-context-menu [role="menuitem"],
@@ -168,4 +275,24 @@
 
 .file-tree-sticky-ancestor-stack .file-tree-row {
   height: var(--file-tree-sticky-row-height, 24px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .file-tree-item[data-row-animation="opening-block"],
+  .file-tree-item[data-row-animation="closing-block"],
+  .file-tree-item[data-row-animation="closing"] {
+    animation: none;
+  }
+
+  .file-tree-row-action {
+    transition: none;
+    transform: translateY(-50%);
+  }
+
+  .file-tree-item[data-is-dir="true"][data-expanded="true"][data-active="true"]
+    .file-tree-row-action,
+  .file-tree-item:focus-within .file-tree-row-action,
+  .file-tree-item:hover .file-tree-row-action {
+    transform: translateY(-50%);
+  }
 }

--- a/src/features/settings/components/tabs/terminal-settings.tsx
+++ b/src/features/settings/components/tabs/terminal-settings.tsx
@@ -165,6 +165,32 @@ export const TerminalSettings = () => {
       </Section>
 
       <Section
+        title="Safety"
+        description="Keep high-risk terminal actions explicit without slowing down normal typing."
+      >
+        <SettingRow
+          label="Confirm Multi-line Paste"
+          description="Warn before pasting multiple lines or large blocks of text into the terminal."
+          onReset={() =>
+            updateSetting(
+              "confirmTerminalMultilinePaste",
+              getDefaultSetting("confirmTerminalMultilinePaste"),
+            )
+          }
+          canReset={
+            settings.confirmTerminalMultilinePaste !==
+            getDefaultSetting("confirmTerminalMultilinePaste")
+          }
+        >
+          <Switch
+            checked={settings.confirmTerminalMultilinePaste}
+            onChange={(checked) => updateSetting("confirmTerminalMultilinePaste", checked)}
+            size="sm"
+          />
+        </SettingRow>
+      </Section>
+
+      <Section
         title="Profiles"
         description="Create reusable launch presets with a shell override, startup directory, and optional startup commands."
       >

--- a/src/features/settings/config/default-settings.ts
+++ b/src/features/settings/config/default-settings.ts
@@ -44,6 +44,7 @@ export const defaultSettings: Settings = {
   terminalCursorWidth: 2,
   terminalDefaultShellId: "",
   terminalDefaultProfileId: "",
+  confirmTerminalMultilinePaste: true,
   // UI
   uiFontFamily: DEFAULT_UI_FONT_FAMILY,
   uiFontSize: UI_FONT_SIZE_DEFAULT,

--- a/src/features/settings/config/search-index.ts
+++ b/src/features/settings/config/search-index.ts
@@ -803,6 +803,14 @@ export const settingsSearchIndex: SettingSearchRecord[] = [
     keywords: ["terminal", "profile", "default", "launch"],
   },
   {
+    id: "terminal-confirm-multiline-paste",
+    tab: "terminal",
+    section: "Safety",
+    label: "Confirm Multi-line Paste",
+    description: "Warn before pasting multiple lines or large blocks of text into the terminal",
+    keywords: ["terminal", "paste", "warning", "confirm", "multiline", "safety"],
+  },
+  {
     id: "terminal-font-family",
     tab: "terminal",
     section: "Typography",

--- a/src/features/settings/types/settings.ts
+++ b/src/features/settings/types/settings.ts
@@ -33,6 +33,7 @@ export interface Settings {
   terminalCursorWidth: number;
   terminalDefaultShellId: string;
   terminalDefaultProfileId: string;
+  confirmTerminalMultilinePaste: boolean;
   // UI
   uiFontFamily: string;
   uiFontSize: number;

--- a/src/features/terminal/components/terminal.tsx
+++ b/src/features/terminal/components/terminal.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { Warning } from "@phosphor-icons/react";
 import type { ISearchOptions } from "@xterm/addon-search";
 import { Terminal } from "@xterm/xterm";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -7,7 +8,9 @@ import { parseRemotePath } from "@/features/remote/utils/remote-path";
 import { useSettingsStore } from "@/features/settings/store";
 import { useZoomStore } from "@/features/window/stores/zoom-store";
 import { useProjectStore } from "@/features/window/stores/project-store";
-import { primitiveConfirm } from "@/ui/primitive-dialog-service";
+import { Button } from "@/ui/button";
+import Checkbox from "@/ui/checkbox";
+import Dialog from "@/ui/dialog";
 import {
   createTerminalAddons,
   injectLinkStyles,
@@ -38,6 +41,11 @@ interface XtermTerminalProps {
   remoteConnectionId?: string;
 }
 
+interface PendingTerminalPaste {
+  text: string;
+  lineCount: number;
+}
+
 export const XtermTerminal: React.FC<XtermTerminalProps> = ({
   sessionId,
   isActive,
@@ -55,6 +63,8 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
   const [isInitialized, setIsInitialized] = useState(false);
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const [searchResults, setSearchResults] = useState({ current: 0, total: 0 });
+  const [pendingPaste, setPendingPaste] = useState<PendingTerminalPaste | null>(null);
+  const [skipPasteWarning, setSkipPasteWarning] = useState(false);
   const isInitializingRef = useRef(false);
 
   const { updateSession, getSession } = useTerminalStore();
@@ -72,13 +82,18 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
     terminalCursorStyle,
     terminalCursorBlink,
     terminalCursorWidth,
+    confirmTerminalMultilinePaste,
   } = useSettingsStore((state) => state.settings);
+  const updateSetting = useSettingsStore((state) => state.updateSetting);
   const zoomLevel = useZoomStore.use.terminalZoomLevel();
   const { rootFolderPath } = useProjectStore();
   const { getTerminalTheme } = useTerminalTheme();
+  const confirmTerminalMultilinePasteRef = useRef(confirmTerminalMultilinePaste);
   const effectiveTerminalFontSize = Math.round(terminalFontSize * zoomLevel * 10) / 10;
   const effectiveTerminalLetterSpacing = terminalLetterSpacing * zoomLevel;
   const effectiveTerminalCursorWidth = Math.max(1, Math.round(terminalCursorWidth * zoomLevel));
+
+  confirmTerminalMultilinePasteRef.current = confirmTerminalMultilinePaste;
 
   const fitTerminal = useCallback((attempts = 1) => {
     let attempt = 0;
@@ -208,15 +223,11 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
               lineCount >= MULTILINE_PASTE_LINE_THRESHOLD ||
               normalizedText.length >= LARGE_PASTE_CHAR_THRESHOLD;
 
-            if (requiresConfirmation) {
+            if (requiresConfirmation && confirmTerminalMultilinePasteRef.current) {
               event.preventDefault();
               event.stopImmediatePropagation();
-              void primitiveConfirm(
-                `Paste ${lineCount} lines into the terminal? This may execute multiple commands.`,
-                { title: "Paste Into Terminal", confirmLabel: "Paste" },
-              ).then((confirmed) => {
-                if (confirmed) writeBuffered(normalizedText);
-              });
+              setSkipPasteWarning(false);
+              setPendingPaste({ text: normalizedText, lineCount });
               return;
             }
 
@@ -731,6 +742,61 @@ export const XtermTerminal: React.FC<XtermTerminalProps> = ({
           }}
         />
       </div>
+      {pendingPaste ? (
+        <Dialog
+          title="Paste Into Terminal"
+          icon={Warning}
+          onClose={() => {
+            setPendingPaste(null);
+            setSkipPasteWarning(false);
+          }}
+          size="sm"
+          footer={
+            <>
+              <Button
+                variant="ghost"
+                compact
+                onClick={() => {
+                  setPendingPaste(null);
+                  setSkipPasteWarning(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="accent"
+                compact
+                onClick={() => {
+                  const nextPaste = pendingPaste;
+                  setPendingPaste(null);
+                  if (skipPasteWarning) {
+                    void updateSetting("confirmTerminalMultilinePaste", false);
+                  }
+                  writeBuffered(nextPaste.text);
+                  setSkipPasteWarning(false);
+                }}
+              >
+                Paste
+              </Button>
+            </>
+          }
+        >
+          <div className="space-y-3">
+            <p className="whitespace-pre-wrap text-text text-xs">
+              Paste {pendingPaste.lineCount} lines into the terminal? This may execute multiple
+              commands.
+            </p>
+            <label className="flex items-center gap-2 text-text text-xs">
+              <Checkbox
+                checked={skipPasteWarning}
+                onChange={setSkipPasteWarning}
+                ariaLabel="Do not show terminal paste warning again"
+              />
+              <span>Do not show again</span>
+            </label>
+          </div>
+        </Dialog>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## What really changes
The file explorer now treats open, close, and collapse as three separate actions instead of blending them together. Normal open and close preserve the folder's previous nested state, while the collapse control intentionally resets the subtree and uses the stepped folder-only collapse animation.

The explorer controls are also more consistent at the workspace root and in sticky ancestor rows, and the terminal multiline paste warning now supports a do-not-show-again flow with a settings toggle to restore it.

## Point by point
- regular folder close now hides the subtree without wiping nested open state
- collapse now stays explicit, resets descendants, and only stair-animates folder rows
- root rows keep their own collapse affordance without collapsing the repo itself
- sticky ancestor rows now keep the same trailing action behavior while scrolling
- multiline terminal paste warnings can be disabled once and turned back on from settings

## Implementation details
- split normal folder close from destructive subtree collapse instead of routing both through one path
- kept workspace root rows on dedicated semantics so the repo itself never disappears
- preserved cached child state for normal close, and reserved descendant state clearing for the explicit collapse control only
- mirrored the trailing action in the sticky ancestor render path so behavior stays aligned between normal and sticky rows
