### PR TITLE
Fix symbol breadcrumb pane state

### DIFF
--- a/src/features/editor/components/toolbar/breadcrumb.tsx
+++ b/src/features/editor/components/toolbar/breadcrumb.tsx
@@ -214,6 +214,7 @@ export default function Breadcrumb({
               />
               <SymbolBreadcrumb
                 bufferId={resolvedBufferId ?? undefined}
+                editorViewKey={editorViewKey}
                 filePath={filePath}
                 interactive={interactive && !isLocalHistorySnapshot}
               />

--- a/src/features/editor/components/toolbar/editor-status-actions.tsx
+++ b/src/features/editor/components/toolbar/editor-status-actions.tsx
@@ -15,6 +15,7 @@ import { LspClient } from "@/features/editor/lsp/lsp-client";
 import { type LspStatus, useLspStore } from "@/features/editor/lsp/stores/lsp.store";
 import type { Position } from "@/features/editor/types/editor.types";
 import { getBufferById } from "@/features/editor/utils/buffer-index";
+import { resolveEditorViewCursorPosition } from "@/features/editor/utils/editor-view-cursor-position";
 import { LoadingIndicator } from "@/ui/loading";
 import { useBufferStore } from "@/features/editor/stores/buffer.store";
 import { useEditorStateStore } from "@/features/editor/stores/state.store";
@@ -78,12 +79,15 @@ function CursorPositionChip({ editorViewKey }: { editorViewKey?: string | null }
   const [draftPosition, setDraftPosition] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const displayedCursorPosition = useMemo<Position>(() => {
-    if (!editorViewKey || activeEditorViewKey === editorViewKey) {
-      return cursorPosition;
-    }
-
-    const cachedCursor = useEditorStateStore.getState().actions.getCachedPosition(editorViewKey);
-    return cachedCursor ?? { line: 0, column: 0, offset: 0 };
+    const cachedCursor = editorViewKey
+      ? useEditorStateStore.getState().actions.getCachedPosition(editorViewKey)
+      : undefined;
+    return resolveEditorViewCursorPosition(
+      editorViewKey,
+      activeEditorViewKey,
+      cursorPosition,
+      cachedCursor,
+    );
   }, [activeEditorViewKey, cursorPosition, editorViewKey]);
   const displayPosition = `${displayedCursorPosition.line + 1}:${displayedCursorPosition.column + 1}`;
 

--- a/src/features/editor/components/toolbar/symbol-breadcrumb.tsx
+++ b/src/features/editor/components/toolbar/symbol-breadcrumb.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { extensionRegistry } from "@/extensions/registry/extension-registry";
+import { useExtensionStore } from "@/extensions/registry/extension-store";
 import { useEditorStateStore } from "@/features/editor/stores/state.store";
+import { resolveEditorViewCursorPosition } from "@/features/editor/utils/editor-view-cursor-position";
 import { useDocumentOutline } from "@/features/outline/hooks/use-document-outline";
 import { findSymbolPathAtPosition } from "@/features/outline/utils/symbol-path";
 import { openOutlineSymbol } from "@/features/outline/utils/outline-symbols";
@@ -10,6 +12,7 @@ import { cn } from "@/utils/cn";
 
 interface SymbolBreadcrumbProps {
   bufferId?: string;
+  editorViewKey?: string | null;
   filePath: string;
   interactive?: boolean;
   className?: string;
@@ -17,37 +20,35 @@ interface SymbolBreadcrumbProps {
 
 export function SymbolBreadcrumb({
   bufferId,
+  editorViewKey,
   filePath,
   interactive = true,
   className,
 }: SymbolBreadcrumbProps) {
   const breadcrumbShowSymbols = useSettingsStore((state) => state.settings.breadcrumbShowSymbols);
 
-  // extensionRegistry populates itself asynchronously on app start (it awaits a Tauri IPC
-  // call before isLspSupported has anything to report). Without this, the very first render
-  // after a cold launch reads isLspSupported as false and nothing re-renders once the
-  // registry finishes loading, so the breadcrumb silently never appears until some unrelated
-  // state change forces a re-render.
-  const [isRegistryReady, setIsRegistryReady] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    extensionRegistry.ensureInitialized().then(() => {
-      if (!cancelled) setIsRegistryReady(true);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const availableExtensions = useExtensionStore.use.availableExtensions();
+  const isExtensionStoreReady = availableExtensions.size > 0;
 
   const isLspSupported = !filePath.includes("://") && extensionRegistry.isLspSupported(filePath);
   const { symbols, isSupported } = useDocumentOutline({
     isActive: breadcrumbShowSymbols && isLspSupported,
     bufferId,
   });
-  // NOTE: cursorPosition is a single GLOBAL store, not per-pane. In an unfocused split
-  // pane, this combines THIS pane's own symbols with the FOCUSED pane's cursor position —
-  // accepted known limitation for v1, do not add per-pane cursor tracking here.
-  const cursorPosition = useEditorStateStore.use.cursorPosition();
+  const activeEditorViewKey = useEditorStateStore.use.activeEditorViewKey();
+  const activeCursorPosition = useEditorStateStore.use.cursorPosition();
+  const cursorPosition = useMemo(() => {
+    const cachedPosition = editorViewKey
+      ? useEditorStateStore.getState().actions.getCachedPosition(editorViewKey)
+      : undefined;
+
+    return resolveEditorViewCursorPosition(
+      editorViewKey,
+      activeEditorViewKey,
+      activeCursorPosition,
+      cachedPosition,
+    );
+  }, [activeCursorPosition, activeEditorViewKey, editorViewKey]);
 
   const symbolChain = useMemo(
     () => findSymbolPathAtPosition(symbols, cursorPosition.line, cursorPosition.column),
@@ -55,7 +56,7 @@ export function SymbolBreadcrumb({
   );
 
   if (
-    !isRegistryReady ||
+    !isExtensionStoreReady ||
     !breadcrumbShowSymbols ||
     !isLspSupported ||
     !isSupported ||

--- a/src/features/editor/tests/editor-view-cursor-position.test.ts
+++ b/src/features/editor/tests/editor-view-cursor-position.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { Position } from "@/features/editor/types/editor.types";
+import { resolveEditorViewCursorPosition } from "@/features/editor/utils/editor-view-cursor-position";
+
+const activePosition: Position = { line: 12, column: 4, offset: 120 };
+const cachedPosition: Position = { line: 3, column: 8, offset: 38 };
+
+describe("resolveEditorViewCursorPosition", () => {
+  it("uses the current position for the active editor view", () => {
+    expect(
+      resolveEditorViewCursorPosition("view-a", "view-a", activePosition, cachedPosition),
+    ).toBe(activePosition);
+  });
+
+  it("uses the cached position for an inactive editor view", () => {
+    expect(
+      resolveEditorViewCursorPosition("view-b", "view-a", activePosition, cachedPosition),
+    ).toBe(cachedPosition);
+  });
+
+  it("falls back to the document start when an inactive view has no cached position", () => {
+    expect(resolveEditorViewCursorPosition("view-b", "view-a", activePosition, null)).toEqual({
+      line: 0,
+      column: 0,
+      offset: 0,
+    });
+  });
+
+  it("uses the current position when no editor view key is available", () => {
+    expect(resolveEditorViewCursorPosition(undefined, "view-a", activePosition)).toBe(
+      activePosition,
+    );
+  });
+});

--- a/src/features/editor/utils/editor-view-cursor-position.ts
+++ b/src/features/editor/utils/editor-view-cursor-position.ts
@@ -1,0 +1,16 @@
+import type { Position } from "@/features/editor/types/editor.types";
+
+const INITIAL_CURSOR_POSITION: Position = { line: 0, column: 0, offset: 0 };
+
+export function resolveEditorViewCursorPosition(
+  editorViewKey: string | null | undefined,
+  activeEditorViewKey: string | null,
+  cursorPosition: Position,
+  cachedPosition?: Position | null,
+): Position {
+  if (!editorViewKey || activeEditorViewKey === editorViewKey) {
+    return cursorPosition;
+  }
+
+  return cachedPosition ?? INITIAL_CURSOR_POSITION;
+}


### PR DESCRIPTION
## Summary

- use each editor view's cached cursor position for symbol breadcrumbs in inactive split panes
- rerender LSP support when extension manifests become available during startup
- share cursor-position resolution with the editor status chip and add regression coverage

## Root cause

The initial symbol breadcrumb implementation combined each pane's symbol tree with the globally active cursor position. Its startup readiness check also waited only for bundled registry initialization, before language extension manifests were registered.

This follows up on #725.

## Validation

- `bunx vp test run src/features/editor/tests/editor-view-cursor-position.test.ts src/features/outline/tests/symbol-path.test.ts`
- `bash scripts/check/frontend.sh`