### PR TITLE
Align stores with createSelectors and centralize row line-height

### DIFF
--- a/src/features/ai/components/input/chat-input-bar.tsx
+++ b/src/features/ai/components/input/chat-input-bar.tsx
@@ -909,7 +909,7 @@ const AIChatInputBar = memo(function AIChatInputBar({
         mentionSpan.setAttribute("contenteditable", "false");
         mentionSpan.title = file.path;
         mentionSpan.className =
-          "font-sans ui-text-sm inline-flex min-h-6 max-w-[180px] items-center gap-1 truncate rounded-full border-0 bg-primary/10 px-1.5 py-0.5 leading-[1.35] text-primary align-baseline select-none";
+          "font-sans ui-text-sm inline-flex min-h-6 max-w-[180px] items-center gap-1 truncate rounded-full border-0 bg-primary/10 px-1.5 py-0.5 leading-row text-primary align-baseline select-none";
         mentionSpan.textContent = file.name;
         inputRef.current.appendChild(mentionSpan);
 
@@ -984,7 +984,7 @@ const AIChatInputBar = memo(function AIChatInputBar({
         commandSpan.setAttribute("contenteditable", "false");
         commandSpan.title = command.description || `/${command.name}`;
         commandSpan.className =
-          "font-sans ui-text-sm inline-flex min-h-6 max-w-[180px] items-center gap-1 truncate rounded-full border-0 bg-accent/70 px-1.5 py-0.5 leading-[1.35] text-foreground align-baseline select-none";
+          "font-sans ui-text-sm inline-flex min-h-6 max-w-[180px] items-center gap-1 truncate rounded-full border-0 bg-accent/70 px-1.5 py-0.5 leading-row text-foreground align-baseline select-none";
         commandSpan.textContent = `/${command.name}`;
         inputRef.current.appendChild(commandSpan);
 

--- a/src/features/ai/components/mentions/ai-file-selector.tsx
+++ b/src/features/ai/components/mentions/ai-file-selector.tsx
@@ -205,7 +205,7 @@ export function AIFileSelector({
                       "px-2 font-medium text-subtle-foreground/75",
                       compact
                         ? "ui-text-sm pt-1 pb-0.5 leading-normal"
-                        : "ui-text-base pt-1.5 pb-1 leading-[1.35]",
+                        : "ui-text-base pt-1.5 pb-1 leading-row",
                     )}
                   >
                     {categoryLabels[category]}

--- a/src/features/ai/components/selectors/context-selector.tsx
+++ b/src/features/ai/components/selectors/context-selector.tsx
@@ -258,7 +258,7 @@ function ContextSelectorDropdownContent({
           leadingContent={
             filteredContextBuffers.length > 0 ? (
               <>
-                <div className="ui-text-sm px-2 pt-1.5 pb-1 font-medium leading-[1.35] text-subtle-foreground/75">
+                <div className="ui-text-sm px-2 pt-1.5 pb-1 font-medium leading-row text-subtle-foreground/75">
                   Open tabs
                 </div>
                 {filteredContextBuffers.map((buffer) => {

--- a/src/features/command-palette/components/command-palette.tsx
+++ b/src/features/command-palette/components/command-palette.tsx
@@ -155,7 +155,7 @@ const CommandPaletteContent = ({ commandPaletteInitialView }: CommandPaletteCont
   const lspStatus = useLspStore.use.lspStatus();
   const rootFolderPath = useFileSystemStore((state) => state.rootFolderPath);
   const activeRepoPath = useRepositoryStore.use.activeRepoPath();
-  const { checkAuth: checkGitHubAuth } = useGitHubStore().actions;
+  const { checkAuth: checkGitHubAuth } = useGitHubStore.use.actions();
   const extensionCommands = useUIExtensionStore.use.commands();
   const extensionViews = useCommandPaletteViews();
   const { showToast } = useToast();

--- a/src/features/database/providers/mongodb/mongodb-viewer.tsx
+++ b/src/features/database/providers/mongodb/mongodb-viewer.tsx
@@ -103,7 +103,7 @@ export default function MongoDBViewer({ connectionId }: MongoDBViewerProps) {
                 variant="ghost"
                 size="xs"
                 className={cn(
-                  "block h-auto w-full justify-start rounded-lg px-2 py-1 text-left ui-text-sm leading-[1.35]",
+                  "block h-auto w-full justify-start rounded-lg px-2 py-1 text-left ui-text-sm leading-row",
                   store.selectedCollection === col.name && "bg-selected",
                 )}
                 aria-label={`Select collection ${col.name}`}

--- a/src/features/database/providers/redis/redis-viewer.tsx
+++ b/src/features/database/providers/redis/redis-viewer.tsx
@@ -149,7 +149,7 @@ export default function RedisViewer({ connectionId }: RedisViewerProps) {
                 variant="ghost"
                 onClick={() => actions.selectKey(keyInfo.key)}
                 className={cn(
-                  "h-auto w-full justify-start gap-1.5 px-2 py-1 leading-[1.35]",
+                  "h-auto w-full justify-start gap-1.5 px-2 py-1 leading-row",
                   store.selectedKey === keyInfo.key && "bg-selected",
                 )}
                 aria-label={`Select key ${keyInfo.key}`}
@@ -162,7 +162,7 @@ export default function RedisViewer({ connectionId }: RedisViewerProps) {
                 >
                   {keyInfo.type.substring(0, 3)}
                 </Badge>
-                <span className="flex-1 truncate leading-[1.35]">{keyInfo.key}</span>
+                <span className="flex-1 truncate leading-row">{keyInfo.key}</span>
                 {keyInfo.ttl > 0 && (
                   <span className="flex items-center gap-0.5 text-subtle-foreground">
                     <Clock />

--- a/src/features/file-explorer/components/file-explorer-tree-item.tsx
+++ b/src/features/file-explorer/components/file-explorer-tree-item.tsx
@@ -1,6 +1,5 @@
 import type React from "react";
 import { memo } from "react";
-import { FILE_TREE_ROW_CLASS_NAME } from "@/features/file-explorer/lib/file-tree-row";
 import type { FileTreeGitStatusDecoration } from "@/features/file-explorer/lib/file-tree-git-status";
 import type { FileEntry } from "@/features/file-system/types/app.types";
 import { InlineRenameInput } from "@/ui/input";
@@ -153,10 +152,7 @@ function FileExplorerTreeItemComponent({
       >
         {renderTreeGuides()}
         <div
-          className={cn(
-            "file-tree-row flex w-full items-center rounded-lg",
-            FILE_TREE_ROW_CLASS_NAME,
-          )}
+          className="file-tree-row flex w-full items-center rounded-lg gap-1.5 px-1.5 py-1 ui-text-sm leading-row"
           style={{
             paddingLeft: `${paddingLeft}px`,
           }}
@@ -223,7 +219,6 @@ function FileExplorerTreeItemComponent({
           file.isSymlink && file.symlinkTarget ? `Symlink to: ${file.symlinkTarget}` : undefined
         }
         className={cn(
-          FILE_TREE_ROW_CLASS_NAME,
           isDragOver && "!border-2 !border-dashed !border-primary !bg-primary !bg-opacity-20",
           isDragging && "cursor-move",
           file.ignored && "opacity-50",

--- a/src/features/file-explorer/lib/file-tree-row.ts
+++ b/src/features/file-explorer/lib/file-tree-row.ts
@@ -10,5 +10,3 @@ export function getFileTreeRowHeight(uiFontSize: number): number {
 
   return Number(height.toFixed(2));
 }
-
-export const FILE_TREE_ROW_CLASS_NAME = "gap-1.5 px-1.5 py-1 ui-text-sm leading-[1.35]";

--- a/src/features/git/components/status/git-status-file-item.tsx
+++ b/src/features/git/components/status/git-status-file-item.tsx
@@ -49,7 +49,7 @@ export const GitFileItem = ({
     <SidebarTreeRow
       depth={indentLevel}
       className={cn(
-        "group grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center overflow-hidden leading-[1.35]",
+        "group grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center overflow-hidden leading-row",
         className,
       )}
       onClick={onClick}
@@ -78,7 +78,7 @@ export const GitFileItem = ({
       >
         <span
           className={cn(
-            "block min-w-0 truncate whitespace-nowrap leading-[1.35]",
+            "block min-w-0 truncate whitespace-nowrap leading-row",
             showDirectory ? "shrink-0 basis-auto max-w-[45%]" : "flex-1",
             "text-foreground",
           )}
@@ -86,7 +86,7 @@ export const GitFileItem = ({
           {fileName}
         </span>
         {showDirectory && directory && (
-          <span className="ui-text-sm block min-w-0 flex-1 truncate whitespace-nowrap leading-[1.35] text-subtle-foreground/80">
+          <span className="ui-text-sm block min-w-0 flex-1 truncate whitespace-nowrap leading-row text-subtle-foreground/80">
             {directory}
           </span>
         )}
@@ -95,7 +95,7 @@ export const GitFileItem = ({
         {hasDiffStats && (
           <div
             className={cn(
-              "flex max-w-[4.75rem] shrink-0 items-center justify-end overflow-hidden leading-[1.35] tabular-nums",
+              "flex max-w-[4.75rem] shrink-0 items-center justify-end overflow-hidden leading-row tabular-nums",
               compactGitStatusBadges ? "ui-text-sm gap-0.5" : "ui-text-sm gap-1",
             )}
           >

--- a/src/features/git/components/status/git-status-panel.tsx
+++ b/src/features/git/components/status/git-status-panel.tsx
@@ -422,7 +422,7 @@ const GitStatusPanel = ({
             <SidebarTreeRow
               depth={depth}
               onClick={() => toggleFolderCollapsed(section, folderNode.fullPath)}
-              className="grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center overflow-hidden leading-[1.35]"
+              className="grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center overflow-hidden leading-row"
               draggable={!!repoPath}
               onDragStart={(event) => {
                 if (!repoPath) return;
@@ -440,7 +440,7 @@ const GitStatusPanel = ({
                 isExpanded={!isCollapsed}
                 className="relative z-1 shrink-0 text-subtle-foreground"
               />
-              <span className="relative z-1 block min-w-0 truncate whitespace-nowrap leading-[1.35]">
+              <span className="relative z-1 block min-w-0 truncate whitespace-nowrap leading-row">
                 {folderNode.name}
               </span>
               <div className="relative z-1 ml-auto shrink-0" onClick={(e) => e.stopPropagation()}>

--- a/src/features/github/components/github-actions-view.tsx
+++ b/src/features/github/components/github-actions-view.tsx
@@ -252,8 +252,8 @@ const GitHubActionsView = memo(
     const rootFolderPath = useFileSystemStore.use.rootFolderPath?.();
     const activeRepoPath = useRepositoryStore.use.activeRepoPath();
     const repoPath = activeRepoPath ?? rootFolderPath ?? null;
-    const { isAuthenticated } = useGitHubStore();
-    const { checkAuth } = useGitHubStore().actions;
+    const isAuthenticated = useGitHubStore.use.isAuthenticated();
+    const { checkAuth } = useGitHubStore.use.actions();
     const { openGitHubActionBuffer } = useBufferStore.use.actions();
     const activeRunId = useBufferStore((state) => {
       const activeBuffer = state.activeBufferId

--- a/src/features/github/components/github-auth-status.tsx
+++ b/src/features/github/components/github-auth-status.tsx
@@ -50,10 +50,10 @@ function GitHubAuthState({
 }
 
 export function GitHubAuthStatusMessage() {
-  const githubAccountStatus = useGitHubStore((s) => s.githubAccountStatus);
-  const authError = useGitHubStore((s) => s.authError);
-  const isCheckingAuth = useGitHubStore((s) => s.isCheckingAuth);
-  const checkAuth = useGitHubStore((s) => s.actions.checkAuth);
+  const githubAccountStatus = useGitHubStore.use.githubAccountStatus();
+  const authError = useGitHubStore.use.authError();
+  const isCheckingAuth = useGitHubStore.use.isCheckingAuth();
+  const checkAuth = useGitHubStore.use.actions().checkAuth;
   const isAthasAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const isAthasAuthLoading = useAuthStore((s) => s.isLoading);
   const { signIn, isSigningIn } = useDesktopSignIn({

--- a/src/features/github/components/github-issues-view.tsx
+++ b/src/features/github/components/github-issues-view.tsx
@@ -139,8 +139,8 @@ const GitHubIssuesView = memo(
     const rootFolderPath = useFileSystemStore.use.rootFolderPath?.();
     const activeRepoPath = useRepositoryStore.use.activeRepoPath();
     const repoPath = activeRepoPath ?? rootFolderPath ?? null;
-    const { isAuthenticated } = useGitHubStore();
-    const { checkAuth } = useGitHubStore().actions;
+    const isAuthenticated = useGitHubStore.use.isAuthenticated();
+    const { checkAuth } = useGitHubStore.use.actions();
     const { openGitHubIssueBuffer } = useBufferStore.use.actions();
     const activeIssueNumber = useBufferStore((state) => {
       const activeBuffer = state.activeBufferId

--- a/src/features/github/components/github-pr-viewer.tsx
+++ b/src/features/github/components/github-pr-viewer.tsx
@@ -97,19 +97,17 @@ const GitHubPRViewer = memo(({ prNumber }: GitHubPRViewerProps) => {
     );
     return buffer?.type === "pullRequest" ? buffer : undefined;
   });
-  const {
-    selectedPRDetails,
-    selectedPRDiff,
-    selectedPRFiles,
-    selectedPRComments,
-    isLoadingDetails,
-    isLoadingContent,
-    detailsError,
-    contentError,
-  } = useGitHubStore();
+  const selectedPRDetails = useGitHubStore.use.selectedPRDetails();
+  const selectedPRDiff = useGitHubStore.use.selectedPRDiff();
+  const selectedPRFiles = useGitHubStore.use.selectedPRFiles();
+  const selectedPRComments = useGitHubStore.use.selectedPRComments();
+  const isLoadingDetails = useGitHubStore.use.isLoadingDetails();
+  const isLoadingContent = useGitHubStore.use.isLoadingContent();
+  const detailsError = useGitHubStore.use.detailsError();
+  const contentError = useGitHubStore.use.contentError();
   const updateBuffer = useBufferStore.use.actions().updateBuffer;
   const { selectPR, fetchPRContent, fetchPRs, openPRInBrowser, checkoutPR } =
-    useGitHubStore().actions;
+    useGitHubStore.use.actions();
   const repoPath = prBuffer?.repoPath ?? selectedRepoPath ?? rootFolderPath;
 
   const [activeTab, setActiveTab] = useState<TabType>(() =>

--- a/src/features/github/components/github-prs-view.tsx
+++ b/src/features/github/components/github-prs-view.tsx
@@ -217,7 +217,11 @@ PRListItem.displayName = "PRListItem";
 
 const GitHubPRsView = memo(() => {
   const rootFolderPath = useFileSystemStore.use.rootFolderPath?.();
-  const { prs, isLoading, error, currentFilter, isAuthenticated } = useGitHubStore();
+  const prs = useGitHubStore.use.prs();
+  const isLoading = useGitHubStore.use.isLoading();
+  const error = useGitHubStore.use.error();
+  const currentFilter = useGitHubStore.use.currentFilter();
+  const isAuthenticated = useGitHubStore.use.isAuthenticated();
   const {
     fetchPRs,
     setFilter,
@@ -226,7 +230,7 @@ const GitHubPRsView = memo(() => {
     openPRInBrowser,
     checkoutPR,
     prefetchPR,
-  } = useGitHubStore().actions;
+  } = useGitHubStore.use.actions();
   const activeRepoPath = useRepositoryStore.use.activeRepoPath();
   const { syncWorkspaceRepositories, setManualRepository } = useRepositoryStore.use.actions();
   const { openPRBuffer, openGitHubIssueBuffer } = useBufferStore.use.actions();

--- a/src/features/github/stores/github.store.ts
+++ b/src/features/github/stores/github.store.ts
@@ -14,6 +14,7 @@ import {
   syncGitHubTokenFromAccount,
   type GitHubTokenSyncStatus,
 } from "../services/github-token-service";
+import { createSelectors } from "@/utils/zustand-selectors";
 
 const PR_LIST_CACHE_TTL_MS = 5 * 60_000;
 const PR_DETAILS_CACHE_TTL_MS = 120_000;
@@ -217,7 +218,7 @@ async function fetchNormalizedPRDetails(
   return normalizePullRequestDetails(detailsResponse);
 }
 
-export const useGitHubStore = create(
+const useGitHubStoreBase = create(
   combine(initialState, (set, get) => ({
     actions: {
       checkAuth: async (options?: { force?: boolean }) => {
@@ -793,3 +794,5 @@ export const useGitHubStore = create(
     },
   })),
 );
+
+export const useGitHubStore = createSelectors(useGitHubStoreBase);

--- a/src/features/panes/components/pane-container.tsx
+++ b/src/features/panes/components/pane-container.tsx
@@ -231,8 +231,8 @@ function BufferPreviewCard({ buffer }: { buffer: PaneRenderBuffer }) {
 }
 
 function PullRequestPreviewCard({ buffer }: { buffer: PullRequestContent }) {
-  const selectedPRDetails = useGitHubStore((state) => state.selectedPRDetails);
-  const selectedPRComments = useGitHubStore((state) => state.selectedPRComments);
+  const selectedPRDetails = useGitHubStore.use.selectedPRDetails();
+  const selectedPRComments = useGitHubStore.use.selectedPRComments();
   const details = selectedPRDetails?.number === buffer.prNumber ? selectedPRDetails : null;
   const fileCount = details ? details.changedFiles : null;
   const commentCount = details ? selectedPRComments.length : null;

--- a/src/features/settings/stores/settings.store.ts
+++ b/src/features/settings/stores/settings.store.ts
@@ -24,6 +24,7 @@ import { settingsSearchIndex } from "../config/search-index";
 import type { SearchResult, SearchState } from "../types/search.types";
 import type { Settings } from "../types/settings.types";
 import { useWorkspaceTabsStore } from "@/features/window/stores/workspace-tabs.store";
+import { createSelectors } from "@/utils/zustand-selectors";
 
 export type { Settings } from "../types/settings.types";
 
@@ -43,7 +44,7 @@ export function initializeSettingsStore(): Promise<Settings> {
   return settingsStoreInitPromise;
 }
 
-export const useSettingsStore = create(
+const useSettingsStoreBase = create(
   immer(
     combine(
       {
@@ -197,5 +198,7 @@ export const useSettingsStore = create(
     ),
   ),
 );
+
+export const useSettingsStore = createSelectors(useSettingsStoreBase);
 
 export { defaultSettings, getDefaultSetting };

--- a/src/features/sidebar/components/sidebar-tree.tsx
+++ b/src/features/sidebar/components/sidebar-tree.tsx
@@ -93,7 +93,7 @@ export const SidebarTreeRow = forwardRef<HTMLButtonElement, SidebarTreeRowProps>
           depth={depth}
           indentSize={indentSize}
           baseIndent={baseIndent}
-          className={cn("gap-1.5 border border-transparent px-1.5 py-1 leading-[1.35]", className)}
+          className={cn("border border-transparent", className)}
           {...props}
         >
           {children}

--- a/src/features/sidebar/components/tree-row.tsx
+++ b/src/features/sidebar/components/tree-row.tsx
@@ -22,7 +22,7 @@ export function TreeRow({
     <button
       type="button"
       className={cn(
-        "file-tree-row font-sans ui-text-sm flex w-full min-w-max cursor-pointer select-none items-center whitespace-nowrap rounded-lg border-none bg-transparent text-left text-foreground outline-none transition-colors duration-[var(--app-duration-fast)] ease-[var(--app-ease-smooth)] hover:bg-accent focus:outline-none",
+        "file-tree-row font-sans ui-text-sm flex w-full min-w-max cursor-pointer select-none items-center whitespace-nowrap rounded-lg border-none bg-transparent text-left text-foreground outline-none transition-colors duration-[var(--app-duration-fast)] ease-[var(--app-ease-smooth)] hover:bg-accent focus:outline-none gap-1.5 px-1.5 py-1 leading-row",
         active && "bg-selected",
         className,
       )}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,6 +1,7 @@
 @theme inline {
   --font-sans: var(--app-font-family);
   --font-mono: var(--editor-font-family);
+  --leading-row: 1.35;
 
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);


### PR DESCRIPTION
This PR wraps the last two stores that were not using createSelectors (GitHub and Settings) and updates the GitHub components to use per-field selectors instead of subscribing to the whole store. The goal was to reduce unnecessary re-renders in places where components only needed a small part of the state.

I also cleaned up the repeated leading-[1.35] usage by adding a shared leading-row token in theme.css. The tree row spacing and typography styles were moved into TreeRow itself, which allowed the FILE_TREE_ROW_CLASS_NAME constant to be removed.

There is no visual or behavior changes from this PR. Everything should look and work the same.