### PR TITLE
Store real version and checksum for cached WASM parsers

### DIFF
--- a/src/features/editor/lib/wasm-parser/checksum.ts
+++ b/src/features/editor/lib/wasm-parser/checksum.ts
@@ -1,0 +1,25 @@
+/**
+ * SHA-256 integrity helpers for cached Tree-sitter WASM parsers.
+ * Uses WebCrypto, available in all Tauri webviews and Node >= 15.
+ */
+
+export async function computeWasmChecksum(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as unknown as ArrayBuffer);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Verify cached parser bytes against a stored checksum.
+ * Entries written before checksums were recorded store an empty string;
+ * those are treated as valid to keep legacy caches readable.
+ */
+export async function isWasmChecksumValid(bytes: Uint8Array, checksum: string): Promise<boolean> {
+  if (!checksum) {
+    return true;
+  }
+
+  const actual = await computeWasmChecksum(bytes);
+  return actual === checksum.toLowerCase();
+}

--- a/src/features/editor/lib/wasm-parser/loader.ts
+++ b/src/features/editor/lib/wasm-parser/loader.ts
@@ -7,8 +7,19 @@ import { Language, Parser, Query } from "web-tree-sitter";
 import treeSitterRuntimeWasmUrl from "web-tree-sitter/web-tree-sitter.wasm?url";
 import { logger } from "../../utils/logger";
 import { indexedDBParserCache } from "./cache-indexeddb";
+import type { ParserCacheEntry } from "./cache-indexeddb";
+import { computeWasmChecksum, isWasmChecksumValid } from "./checksum";
 import { fetchHighlightQuery } from "./extension-assets";
 import type { LoadedParser, ParserConfig } from "../../types/wasm-parser/wasm-parser.types";
+
+async function resolveParserVersion(languageId: string): Promise<string> {
+  try {
+    const { getLanguageExtensionById } = await import("@/extensions/languages/language-packager");
+    return getLanguageExtensionById(languageId)?.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
 
 export function getTreeSitterRuntimeAssetPath(scriptName: string): string {
   if (scriptName === "web-tree-sitter.wasm") {
@@ -547,9 +558,43 @@ class WasmParserLoader {
       throw new Error(`Cache entry for ${languageId} has no WASM data`);
     }
 
+    if (!(await isWasmChecksumValid(wasmBytes, cached.checksum))) {
+      logger.warn(
+        "WasmParser",
+        `Checksum mismatch for cached parser ${languageId}, re-downloading`,
+      );
+      await indexedDBParserCache.delete(languageId);
+      return null;
+    }
+
     return {
       wasmBytes,
       queryText: cached.highlightQuery?.trim() ? cached.highlightQuery : undefined,
+    };
+  }
+
+  private async createCacheEntry(
+    languageId: string,
+    wasmBytes: Uint8Array,
+    queryText: string | undefined,
+    sourceUrl: string,
+  ): Promise<ParserCacheEntry> {
+    const [checksum, version] = await Promise.all([
+      computeWasmChecksum(wasmBytes),
+      resolveParserVersion(languageId),
+    ]);
+
+    return {
+      languageId,
+      wasmBlob: new Blob([wasmBytes as BlobPart]), // Legacy compatibility
+      wasmData: wasmBytes.buffer as ArrayBuffer, // Preferred: ArrayBuffer
+      highlightQuery: queryText || "",
+      version,
+      checksum,
+      downloadedAt: Date.now(),
+      lastUsedAt: Date.now(),
+      size: wasmBytes.byteLength,
+      sourceUrl,
     };
   }
 
@@ -608,18 +653,9 @@ class WasmParserLoader {
 
           // Cache for future use
           try {
-            await indexedDBParserCache.set({
-              languageId,
-              wasmBlob: new Blob([wasmBytes as BlobPart]), // Legacy compatibility
-              wasmData: wasmBytes.buffer as ArrayBuffer, // Preferred: ArrayBuffer
-              highlightQuery: queryText || "",
-              version: "1.0.0", // TODO: Get version from manifest
-              checksum: "", // TODO: Calculate checksum
-              downloadedAt: Date.now(),
-              lastUsedAt: Date.now(),
-              size: wasmBytes.byteLength,
-              sourceUrl: wasmPath,
-            });
+            await indexedDBParserCache.set(
+              await this.createCacheEntry(languageId, wasmBytes, queryText, wasmPath),
+            );
             logger.debug("WasmParser", `Cached ${languageId} to IndexedDB`);
           } catch (cacheError) {
             logger.warn("WasmParser", `Failed to cache ${languageId}:`, cacheError);
@@ -664,18 +700,9 @@ class WasmParserLoader {
 
           // Cache local parsers to IndexedDB for future use
           try {
-            await indexedDBParserCache.set({
-              languageId,
-              wasmBlob: new Blob([wasmBytes as BlobPart]),
-              wasmData: wasmBytes.buffer as ArrayBuffer,
-              highlightQuery: queryText || "",
-              version: "1.0.0",
-              checksum: "",
-              downloadedAt: Date.now(),
-              lastUsedAt: Date.now(),
-              size: wasmBytes.byteLength,
-              sourceUrl: wasmPath,
-            });
+            await indexedDBParserCache.set(
+              await this.createCacheEntry(languageId, wasmBytes, queryText, wasmPath),
+            );
             logger.debug("WasmParser", `Cached ${languageId} to IndexedDB (from local path)`);
           } catch (cacheError) {
             logger.warn("WasmParser", `Failed to cache ${languageId}:`, cacheError);

--- a/src/features/editor/tests/wasm-parser-checksum.test.ts
+++ b/src/features/editor/tests/wasm-parser-checksum.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vite-plus/test";
+import { computeWasmChecksum, isWasmChecksumValid } from "../lib/wasm-parser/checksum";
+
+const encoder = new TextEncoder();
+
+describe("computeWasmChecksum", () => {
+  it("produces the known SHA-256 digest for a byte sequence", async () => {
+    const checksum = await computeWasmChecksum(encoder.encode("abc"));
+
+    expect(checksum).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  });
+
+  it("returns a 64 character lowercase hex string for empty content", async () => {
+    const checksum = await computeWasmChecksum(new Uint8Array(0));
+
+    expect(checksum).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    expect(checksum).toHaveLength(64);
+  });
+});
+
+describe("isWasmChecksumValid", () => {
+  it("accepts bytes whose checksum matches the stored value", async () => {
+    const bytes = encoder.encode("parser-bytes");
+    const checksum = await computeWasmChecksum(bytes);
+
+    await expect(isWasmChecksumValid(bytes, checksum)).resolves.toBe(true);
+  });
+
+  it("rejects bytes that no longer match the stored checksum", async () => {
+    const bytes = encoder.encode("parser-bytes");
+    const otherChecksum = await computeWasmChecksum(encoder.encode("tampered"));
+
+    await expect(isWasmChecksumValid(bytes, otherChecksum)).resolves.toBe(false);
+  });
+
+  it("treats legacy entries without a stored checksum as valid", async () => {
+    await expect(isWasmChecksumValid(encoder.encode("anything"), "")).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
Store real version and checksum for cached WASM parsers

## Problem

Cached tree-sitter parser entries were written with a hardcoded `version: "1.0.0"` and an empty `checksum` (the two TODOs in `loader.ts`). The cache metadata carried no real information, and there was no way to detect corrupted or tampered parser bytes on disk.

## Changes

- New `src/features/editor/lib/wasm-parser/checksum.ts`: SHA-256 over the WASM bytes via WebCrypto (`crypto.subtle.digest`), plus a verification helper.
- Cache writes (both the remote-download and local-path sites, now sharing one `createCacheEntry` builder) store:
  - the real SHA-256 checksum of the bytes,
  - the parser version resolved from the language extension manifest via `getLanguageExtensionById`, falling back to `"unknown"`.
- Cache reads verify the stored checksum. On mismatch the entry is deleted and treated as a cache miss so the loader re-downloads instead of loading broken bytes. Entries written before this change have an empty checksum and remain valid, so no user is forced to re-download.

## Testing

- New tests: `src/features/editor/tests/wasm-parser-checksum.test.ts` covers known SHA-256 vectors ("abc" and empty input), match/mismatch verification, and the legacy empty-checksum case.
- Full suite passes: 358 files, 1755 tests. Typecheck and lint pass.
- `bun check` still reports 5 pre-existing `cargo fmt` diffs that also appear on a clean checkout of `main` (stable rustfmt cannot apply the nightly-only options); nothing new from this change.

I agree to the Contributor License and Feedback Agreement.
