### PR TITLE
Add unit tests for shared quick-open and tabs utilities

### DIFF
--- a/src/features/quick-open/tests/file-filtering.test.ts
+++ b/src/features/quick-open/tests/file-filtering.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { RecentFile } from "@/features/file-system/types/recent-files.types";
+import { filterQuickOpenRecentFiles, shouldIgnoreFile } from "../utils/file-filtering";
+
+function makeRecentFile(path: string, overrides: Partial<RecentFile> = {}): RecentFile {
+  return {
+    path,
+    name: path.split("/").pop() ?? path,
+    lastAccessed: "2026-01-01T00:00:00.000Z",
+    accessCount: 1,
+    frecencyScore: 1,
+    workspacePath: "/workspace",
+    ...overrides,
+  };
+}
+
+describe("shouldIgnoreFile", () => {
+  it("ignores files inside dependency and build directories", () => {
+    expect(shouldIgnoreFile("/workspace/node_modules/lib/index.js")).toBe(true);
+    expect(shouldIgnoreFile("/workspace/dist/bundle.min.js")).toBe(true);
+    expect(shouldIgnoreFile("src/target/debug/app.rs")).toBe(true);
+  });
+
+  it("ignores lockfiles and OS metadata files", () => {
+    expect(shouldIgnoreFile("/workspace/package-lock.json")).toBe(true);
+    expect(shouldIgnoreFile("/workspace/Cargo.lock")).toBe(true);
+    expect(shouldIgnoreFile("/workspace/.DS_Store")).toBe(true);
+  });
+
+  it("keeps regular source files", () => {
+    expect(shouldIgnoreFile("/workspace/src/main.ts")).toBe(false);
+    expect(shouldIgnoreFile("/workspace/README.md")).toBe(false);
+  });
+});
+
+describe("filterQuickOpenRecentFiles", () => {
+  const indexedPaths = new Set(["/workspace/src/a.ts", "/workspace/src/b.ts"]);
+
+  it("drops recent files from other workspaces", () => {
+    const filtered = filterQuickOpenRecentFiles(
+      [
+        makeRecentFile("/workspace/src/a.ts"),
+        makeRecentFile("/other/src/c.ts", { workspacePath: "/other" }),
+      ],
+      "/workspace",
+      indexedPaths,
+      true,
+    );
+
+    expect(filtered.map((file) => file.path)).toEqual(["/workspace/src/a.ts"]);
+  });
+
+  it("keeps files that exist in the workspace index", () => {
+    const filtered = filterQuickOpenRecentFiles(
+      [makeRecentFile("/workspace/src/a.ts"), makeRecentFile("/workspace/src/deleted.ts")],
+      "/workspace",
+      indexedPaths,
+      true,
+    );
+
+    expect(filtered.map((file) => file.path)).toEqual(["/workspace/src/a.ts"]);
+  });
+
+  it("keeps external and unindexed files while the file tree has not loaded", () => {
+    const filtered = filterQuickOpenRecentFiles(
+      [
+        makeRecentFile("/outside/d.ts", { external: true }),
+        makeRecentFile("/workspace/src/unindexed.ts"),
+      ],
+      "/workspace",
+      indexedPaths,
+      false,
+    );
+
+    expect(filtered).toHaveLength(2);
+  });
+
+  it("keeps indexed files when no root folder is open", () => {
+    const filtered = filterQuickOpenRecentFiles(
+      [
+        makeRecentFile("/anywhere/x.ts", { workspacePath: null }),
+        makeRecentFile("/workspace/src/a.ts"),
+      ],
+      null,
+      indexedPaths,
+      true,
+    );
+
+    // Without a root folder everything belongs to the workspace,
+    // but loaded indexes still gate which files exist.
+    expect(filtered.map((file) => file.path)).toEqual(["/workspace/src/a.ts"]);
+  });
+});

--- a/src/features/quick-open/tests/fuzzy-search.test.ts
+++ b/src/features/quick-open/tests/fuzzy-search.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vite-plus/test";
+import { fuzzyScore } from "../utils/fuzzy-search";
+
+describe("fuzzyScore", () => {
+  it("scores exact matches highest, ignoring case", () => {
+    expect(fuzzyScore("Button", "button")).toBe(1000);
+    expect(fuzzyScore("README.md", "readme.md")).toBe(1000);
+  });
+
+  it("scores prefix matches above substring matches", () => {
+    const prefix = fuzzyScore("use-file-search", "use-");
+    const substring = fuzzyScore("hooks/use-file-search.ts", "file");
+
+    expect(prefix).toBe(800);
+    expect(substring).toBe(600);
+  });
+
+  it("returns 0 for empty queries and short queries without substring matches", () => {
+    expect(fuzzyScore("anything", "")).toBe(0);
+    // Queries of two characters or less only match substrings
+    expect(fuzzyScore("abcdef", "xb")).toBe(0);
+  });
+
+  it("returns 0 when the text does not contain the query characters in order", () => {
+    expect(fuzzyScore("settings-dialog", "dialog-settings")).toBe(0);
+    expect(fuzzyScore("abc", "xyz")).toBe(0);
+  });
+
+  it("scores subsequence fuzzy matches positively and rewards consecutive runs", () => {
+    const spreadOut = fuzzyScore("use-file-search", "usr");
+    const consecutive = fuzzyScore("user-profile", "usr");
+
+    expect(spreadOut).toBeGreaterThan(0);
+    expect(consecutive).toBeGreaterThan(spreadOut);
+  });
+
+  it("rejects sparse subsequences that fall below the density threshold", () => {
+    // Matching every character would need too many gaps across the text,
+    // so the scorer returns 0 to avoid garbage results.
+    expect(fuzzyScore("a-very-long-component-name-in-a-deep-folder", "avldnmt")).toBe(0);
+  });
+});

--- a/src/features/tabs/tests/path-shortener.test.ts
+++ b/src/features/tabs/tests/path-shortener.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { EditorContent } from "@/features/panes/types/pane-content.types";
+import { calculateDisplayNames } from "../utils/path-shortener";
+
+function makeEditorBuffer(id: string, path: string, isVirtual = false): EditorContent {
+  return {
+    id,
+    type: "editor",
+    path,
+    name: path.split("/").pop() ?? path,
+    content: "",
+    savedContent: "",
+    isDirty: false,
+    isVirtual,
+    isPinned: false,
+    isPreview: false,
+    isActive: false,
+    language: "typescript",
+    tokens: [],
+  };
+}
+
+describe("calculateDisplayNames", () => {
+  it("shows the bare filename when it is unique across buffers", () => {
+    const names = calculateDisplayNames(
+      [
+        makeEditorBuffer("a", "/workspace/src/app.ts"),
+        makeEditorBuffer("b", "/workspace/lib/util.ts"),
+      ],
+      "/workspace",
+    );
+
+    expect(names.get("a")).toBe("app.ts");
+    expect(names.get("b")).toBe("util.ts");
+  });
+
+  it("disambiguates duplicate filenames with their parent directory", () => {
+    const names = calculateDisplayNames(
+      [
+        makeEditorBuffer("a", "/workspace/client/index.ts"),
+        makeEditorBuffer("b", "/workspace/server/index.ts"),
+      ],
+      "/workspace",
+    );
+
+    expect(names.get("a")).toBe("../client/index.ts");
+    expect(names.get("b")).toBe("../server/index.ts");
+  });
+
+  it("walks further up the path until duplicates become distinct", () => {
+    const names = calculateDisplayNames(
+      [
+        makeEditorBuffer("a", "/workspace/packages/web/src/index.ts"),
+        makeEditorBuffer("b", "/workspace/packages/api/src/index.ts"),
+        makeEditorBuffer("c", "/workspace/docs/src/index.ts"),
+      ],
+      "/workspace",
+    );
+
+    // One parent segment is not enough (two "src" folders), two are.
+    expect(names.get("a")).toBe("../web/src/index.ts");
+    expect(names.get("b")).toBe("../api/src/index.ts");
+    expect(names.get("c")).toBe("../docs/src/index.ts");
+  });
+
+  it("falls back to the full relative path for identical paths", () => {
+    const names = calculateDisplayNames(
+      [
+        makeEditorBuffer("a", "/workspace/dup/index.ts"),
+        makeEditorBuffer("b", "/workspace/dup/index.ts"),
+      ],
+      "/workspace",
+    );
+
+    expect(names.get("a")).toBe("../workspace/dup/index.ts");
+    expect(names.get("b")).toBe("../workspace/dup/index.ts");
+  });
+
+  it("uses the buffer name for virtual buffers", () => {
+    const names = calculateDisplayNames(
+      [makeEditorBuffer("term", "", true), makeEditorBuffer("file", "/workspace/a.ts")],
+      "/workspace",
+    );
+
+    expect(names.has("term")).toBe(true);
+    expect(names.get("file")).toBe("a.ts");
+  });
+});

--- a/src/features/tabs/utils/path-shortener.ts
+++ b/src/features/tabs/utils/path-shortener.ts
@@ -8,8 +8,10 @@ function getPathSegments(filePath: string): string[] {
   // Normalize path separators to forward slash
   const normalized = filePath.replace(/\\/g, "/");
   const parts = normalized.split("/");
+  // Drop empty segments caused by absolute-path leading slashes
+  const nonEmptyParts = parts.filter((part) => part.length > 0);
   // Return all parts except the last one (filename)
-  return parts.slice(0, -1);
+  return nonEmptyParts.slice(0, -1);
 }
 
 /**


### PR DESCRIPTION
Add unit tests for shared quick-open and tabs utilities

## What

Adds the first direct unit tests for three widely used but untested utilities:

- `src/features/quick-open/utils/fuzzy-search.ts` — `fuzzyScore` scoring tiers (exact 1000 / prefix 800 / substring 600), case insensitivity, short-query substring-only rule, subsequence scoring with consecutive-match rewards, and the density guard that rejects sparse matches.
- `src/features/quick-open/utils/file-filtering.ts` — `shouldIgnoreFile` against dependency/build directories, lockfiles, and OS metadata, plus `filterQuickOpenRecentFiles` workspace membership, index gating, external files before the file tree loads, and the no-root-folder case.
- `src/features/tabs/utils/path-shortener.ts` — `calculateDisplayNames` bare filenames for unique paths, minimal parent-directory disambiguation for duplicate names, walking further up as needed, full-path fallback, and virtual buffer passthrough.

These helpers back quick open, global search, AI file mentions, the file explorer, and the tab bar.

## Bug found while writing tests

Absolute paths produce an empty first segment when split on `/` (e.g. `"/workspace/dup/index.ts"` yields `["", "workspace", "dup", "index.ts"]`). The fallback display path joined those segments directly, rendering double slashes like `..//workspace/dup/index.ts`. `getPathSegments` now drops empty segments.

## Testing

18 new tests across 3 files; full suite passes: 360 files, 1768 tests. Typecheck and lint pass. `bun check` reports only the pre-existing `cargo fmt` diffs that also appear on clean `main`.

I agree to the Contributor License and Feedback Agreement.
