### PR TITLE
Resolve home-relative SSH keys and expose connection errors

### DIFF
--- a/crates/remote/src/ssh_helpers.rs
+++ b/crates/remote/src/ssh_helpers.rs
@@ -1,5 +1,10 @@
 use ssh2::Session;
-use std::{env, fs, io::Read, net::TcpStream, path::Path};
+use std::{
+   env, fs,
+   io::Read,
+   net::TcpStream,
+   path::{Path, PathBuf},
+};
 
 #[derive(Debug, Clone)]
 struct SshConfig {
@@ -51,6 +56,16 @@ pub(super) fn exec_remote_command(session: &Session, command: &str) -> Result<St
    }
 
    Ok(stdout)
+}
+
+fn expand_identity_path(key_path: &str, home_dir: &Path) -> PathBuf {
+   if key_path == "~" {
+      home_dir.to_path_buf()
+   } else if let Some(relative_path) = key_path.strip_prefix("~/") {
+      home_dir.join(relative_path)
+   } else {
+      PathBuf::from(key_path)
+   }
 }
 
 fn get_ssh_config(host: &str) -> SshConfig {
@@ -131,18 +146,23 @@ pub(super) fn create_ssh_session(
    let actual_port = ssh_config.port.unwrap_or(port);
    let actual_username = ssh_config.user.as_deref().unwrap_or(username);
 
-   let tcp = TcpStream::connect(format!("{}:{}", actual_host, actual_port)).map_err(|e| {
+   let tcp_stream =
+      TcpStream::connect(format!("{}:{}", actual_host, actual_port)).map_err(|e| {
+         format!(
+            "Failed to connect to {}:{}: {}",
+            actual_host, actual_port, e
+         )
+      })?;
+
+   let mut session = Session::new().map_err(|e| format!("Failed to create session: {}", e))?;
+   session.set_tcp_stream(tcp_stream);
+   session.handshake().map_err(|error| {
       format!(
-         "Failed to connect to {}:{}: {}",
-         actual_host, actual_port, e
+         "SSH handshake with {}:{} failed before authentication: {}. No private key has been read \
+          yet; check the server SSH logs and network connection.",
+         actual_host, actual_port, error
       )
    })?;
-
-   let mut sess = Session::new().map_err(|e| format!("Failed to create session: {}", e))?;
-   sess.set_tcp_stream(tcp);
-   sess
-      .handshake()
-      .map_err(|e| format!("Failed to handshake: {}", e))?;
 
    let home_dir = env::var("HOME").unwrap_or_default();
    let default_key_paths = [
@@ -151,39 +171,37 @@ pub(super) fn create_ssh_session(
       format!("{}/.ssh/id_ecdsa", home_dir),
    ];
 
-   let key_file = key_path
+   let configured_key_path = key_path
+      .filter(|path| !path.is_empty())
       .or(ssh_config.identity_file.as_deref())
-      .filter(|path| !path.is_empty() && Path::new(path).exists())
-      .or_else(|| {
-         default_key_paths
-            .iter()
-            .find(|path| Path::new(path).exists())
-            .map(|s| s.as_str())
-      })
-      .unwrap_or("");
+      .map(|path| expand_identity_path(path, Path::new(&home_dir)));
 
-   let mut keys_to_try: Vec<String> = Vec::new();
-   if !key_file.is_empty() && Path::new(key_file).exists() {
-      keys_to_try.push(key_file.to_string());
+   let mut keys_to_try = Vec::new();
+   if let Some(key_path) = configured_key_path {
+      keys_to_try.push(key_path);
    }
 
    for default_key in &default_key_paths {
-      if Path::new(default_key).exists() && !keys_to_try.contains(default_key) {
-         keys_to_try.push(default_key.clone());
+      let default_key_path = PathBuf::from(default_key);
+      if default_key_path.is_file() && !keys_to_try.contains(&default_key_path) {
+         keys_to_try.push(default_key_path);
       }
    }
 
+   let mut authentication_errors = Vec::new();
    for key in &keys_to_try {
-      log::info!("Attempting key authentication with: {}", key);
-      match sess.userauth_pubkey_file(actual_username, None, Path::new(key), None) {
+      log::info!("Attempting key authentication with: {}", key.display());
+      match session.userauth_pubkey_file(actual_username, None, key, None) {
          Ok(()) => {
-            if sess.authenticated() {
-               log::info!("Key authentication successful with: {}", key);
-               return Ok(sess);
+            if session.authenticated() {
+               log::info!("Key authentication successful with: {}", key.display());
+               return Ok(session);
             }
          }
          Err(e) => {
-            log::debug!("Key {} failed: {}", key, e);
+            let key_error = format!("Key {} failed: {}", key.display(), e);
+            log::debug!("{}", key_error);
+            authentication_errors.push(key_error);
          }
       }
    }
@@ -196,15 +214,16 @@ pub(super) fn create_ssh_session(
       "Trying SSH agent authentication for user '{}'...",
       actual_username
    );
-   match sess.userauth_agent(actual_username) {
+   match session.userauth_agent(actual_username) {
       Ok(()) => {
-         if sess.authenticated() {
+         if session.authenticated() {
             log::info!("SSH agent authentication successful");
-            return Ok(sess);
+            return Ok(session);
          }
          log::warn!("SSH agent auth returned Ok but not authenticated");
       }
       Err(e) => {
+         authentication_errors.push(format!("SSH agent authentication failed: {}", e));
          log::warn!(
             "SSH agent authentication failed: {} (try running: ssh-add ~/.ssh/id_rsa)",
             e
@@ -214,21 +233,25 @@ pub(super) fn create_ssh_session(
 
    if let Some(pass) = password {
       log::debug!("Trying password authentication...");
-      sess
+      session
          .userauth_password(actual_username, pass)
          .map_err(|e| format!("Password authentication failed: {}", e))?;
    } else {
-      return Err(
-         "No valid authentication method available. Please provide a password or ensure your SSH \
-          key is properly configured."
-            .to_string(),
-      );
+      return Err(format!(
+         "No valid authentication method available. {}. For an encrypted private key, unlock it \
+          with ssh-add and retry using the SSH agent.",
+         authentication_errors.join("; ")
+      ));
    }
 
-   if !sess.authenticated() {
+   if !session.authenticated() {
       return Err("Authentication failed with all available methods".to_string());
    }
 
    log::info!("Authentication successful!");
-   Ok(sess)
+   Ok(session)
 }
+
+#[cfg(test)]
+#[path = "../tests/ssh/session.rs"]
+mod tests;

--- a/crates/remote/tests/ssh/session.rs
+++ b/crates/remote/tests/ssh/session.rs
@@ -1,0 +1,89 @@
+use super::expand_identity_path;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn expands_home_relative_identity_paths() {
+   let home_dir = Path::new("/home/ssh-user");
+   assert_eq!(
+      expand_identity_path("~/.ssh/custom_ed25519", home_dir),
+      home_dir.join(".ssh/custom_ed25519")
+   );
+   assert_eq!(expand_identity_path("~", home_dir), home_dir);
+}
+
+#[test]
+fn preserves_absolute_relative_and_named_user_paths() {
+   for key_path in [
+      "/keys/id_ed25519",
+      ".ssh/id_ed25519",
+      "~other/.ssh/id_ed25519",
+   ] {
+      assert_eq!(
+         expand_identity_path(key_path, Path::new("/home/ssh-user")),
+         PathBuf::from(key_path)
+      );
+   }
+}
+
+#[test]
+fn handshake_failure_reports_endpoint_and_stage() {
+   let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+   let port = listener.local_addr().unwrap().port();
+   let server = std::thread::spawn(move || {
+      let (connection, _) = listener.accept().unwrap();
+      connection.shutdown(std::net::Shutdown::Both).unwrap();
+   });
+   let error = super::create_ssh_session("127.0.0.1", port, "test", None, None)
+      .err()
+      .expect("a closed socket must fail the handshake");
+   server.join().unwrap();
+   assert!(error.contains(&format!("127.0.0.1:{}", port)), "{error}");
+   assert!(error.contains("before authentication"), "{error}");
+   assert!(
+      error.contains("No private key has been read yet"),
+      "{error}"
+   );
+}
+
+#[test]
+#[ignore = "requires a local SSH server and ATHAS_SSH_TEST_PORT, ATHAS_SSH_TEST_USER, \
+            ATHAS_SSH_TEST_KEY"]
+fn authenticates_with_openssh_identity() {
+   let port = std::env::var("ATHAS_SSH_TEST_PORT")
+      .unwrap()
+      .parse()
+      .unwrap();
+   let username = std::env::var("ATHAS_SSH_TEST_USER").unwrap();
+   let key_path = std::env::var("ATHAS_SSH_TEST_KEY").unwrap();
+   let session = super::create_ssh_session("127.0.0.1", port, &username, None, Some(&key_path))
+      .unwrap_or_else(|error| panic!("{error}"));
+   assert!(session.authenticated());
+   assert_eq!(
+      super::exec_remote_command(&session, "printf athas-ssh-ok").unwrap(),
+      "athas-ssh-ok"
+   );
+   session
+      .sftp()
+      .expect("SFTP should work after key authentication");
+}
+
+#[test]
+#[ignore = "requires a local SSH server and ATHAS_SSH_TEST_PORT, ATHAS_SSH_TEST_USER, \
+            ATHAS_SSH_TEST_KEY"]
+fn reports_configured_key_failure() {
+   let port = std::env::var("ATHAS_SSH_TEST_PORT")
+      .unwrap()
+      .parse()
+      .unwrap();
+   let username = std::env::var("ATHAS_SSH_TEST_USER").unwrap();
+   let missing_key_path = format!("{}.missing", std::env::var("ATHAS_SSH_TEST_KEY").unwrap());
+   let error =
+      super::create_ssh_session("127.0.0.1", port, &username, None, Some(&missing_key_path))
+         .err()
+         .expect("a missing key must fail authentication on the isolated test server");
+   assert!(error.contains(".missing failed:"), "{error}");
+   assert!(
+      error.contains("SSH agent authentication failed:"),
+      "{error}"
+   );
+}


### PR DESCRIPTION
Resolve home-relative private key paths and expose SSH connection failures that were hidden behind a generic authentication error.

- Expand `~/` in the entered private key path before authentication, and try explicitly configured paths even when missing so their errors remain visible by @SnaetWarre.
- Preserve key and agent errors when authentication fails, and identify handshake failures as occurring before any private key is read by @SnaetWarre.
- Add path and handshake regression tests plus opt-in OpenSSH authentication, remote command, SFTP, and missing-key tests by @SnaetWarre.
- Validate with `bun check:rust` (passes with six existing warnings in unrelated app code), `cargo test -p athas-remote --lib` (3 passed, 2 opt-in tests ignored), and a separate run of both opt-in tests against an isolated loopback OpenSSH 10.5p1 server (2 passed) by @SnaetWarre.
- Closes #747.

The loopback server accepted only a freshly generated Ed25519 key in `OPENSSH PRIVATE KEY` format. The test supplied its path using `~/`, disabled access to the real SSH agent, executed `printf athas-ssh-ok`, and opened SFTP. The system OpenSSH client also connected successfully. Running the same two live regression tests against `master` at `2c25c47b` failed both tests with the old generic authentication error; both passed with this change. No keys or credentials are included in the PR.

To run the opt-in tests, configure an isolated SSH server for the current local user with only a disposable test key authorized, enable SFTP, and set `ATHAS_SSH_TEST_PORT`, `ATHAS_SSH_TEST_USER`, and `ATHAS_SSH_TEST_KEY` (a literal `~/` path). Point `SSH_AUTH_SOCK` at a nonexistent socket, then run `cargo test -p athas-remote --lib -- --ignored`.

Validation ran on Linux with Bun 1.3.13 (the installed version; the repository specifies 1.3.2). A preliminary test attempt with `--no-default-features` failed because this crate requires `tauri::Wry`; the normal default-feature test command above passes. The reporter's macOS 27 beta / OpenSSH 10.2 environment was unavailable, so the reported banner-send failure remains unverified. The verified fix covers home-relative key paths and authentication diagnostics. Encrypted keys still use the existing SSH-agent flow; this change does not add a passphrase field or change SSH dependencies.
